### PR TITLE
Fix BRP072C devices not working

### DIFF
--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 import logging
 import socket
+from ssl import SSLContext
 from typing import Optional
 from urllib.parse import unquote
 
@@ -33,6 +34,7 @@ class Appliance(DaikinPowerMixin):  # pylint: disable=too-many-public-methods
     base_url: str
     headers: Optional[dict]
     session: Optional[ClientSession]
+    ssl_context: Optional[SSLContext]
 
     TRANSLATIONS = {}
 
@@ -143,7 +145,7 @@ class Appliance(DaikinPowerMixin):  # pylint: disable=too-many-public-methods
         # passed to pydaikin (homeassistant for instance)
         async with self.request_semaphore:
             async with self.session.get(
-                f'{self.base_url}/{path}', params=params, headers=headers
+                f'{self.base_url}/{path}', params=params, headers=headers, ssl_context=self.ssl_context
             ) as response:
                 if response.status == 403:
                     raise HTTPForbidden(reason=f"HTTP 403 Forbidden for {response.url}")

--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -31,6 +31,7 @@ class Appliance(DaikinPowerMixin):  # pylint: disable=too-many-public-methods
     """Daikin main appliance class."""
 
     base_url: str
+    headers: Optional[dict]
     session: Optional[ClientSession]
 
     TRANSLATIONS = {}
@@ -132,13 +133,17 @@ class Appliance(DaikinPowerMixin):  # pylint: disable=too-many-public-methods
         if params is None:
             params = {}
 
-        _LOGGER.debug("Calling: %s/%s %s", self.base_url, path, params)
+        headers = self.headers
+        if headers is None:
+            headers = {}
+
+        _LOGGER.debug("Calling: %s/%s %s [%s]", self.base_url, path, params, headers)
 
         # cannot manage session on outer async with or this will close the session
         # passed to pydaikin (homeassistant for instance)
         async with self.request_semaphore:
             async with self.session.get(
-                f'{self.base_url}/{path}', params=params
+                f'{self.base_url}/{path}', params=params, headers=headers
             ) as response:
                 if response.status == 403:
                     raise HTTPForbidden(reason=f"HTTP 403 Forbidden for {response.url}")

--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -145,7 +145,10 @@ class Appliance(DaikinPowerMixin):  # pylint: disable=too-many-public-methods
         # passed to pydaikin (homeassistant for instance)
         async with self.request_semaphore:
             async with self.session.get(
-                f'{self.base_url}/{path}', params=params, headers=headers, ssl_context=self.ssl_context
+                f'{self.base_url}/{path}',
+                params=params,
+                headers=headers,
+                ssl_context=self.ssl_context,
             ) as response:
                 if response.status == 403:
                     raise HTTPForbidden(reason=f"HTTP 403 Forbidden for {response.url}")

--- a/pydaikin/daikin_brp072c.py
+++ b/pydaikin/daikin_brp072c.py
@@ -20,7 +20,7 @@ class DaikinBRP072C(DaikinBRP069):
         if uuid is None:
             uuid = uuid3(NAMESPACE_OID, 'pydaikin')
         self._uuid = str(uuid).replace('-', '')
-        self._headers = {"X-Daikin-uuid": self._uuid}
+        self.headers = {"X-Daikin-uuid": self._uuid}
         self._ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
         # SSL_OP_LEGACY_SERVER_CONNECT, https://github.com/python/cpython/issues/89051
         self._ssl_context.options |= 0x4

--- a/pydaikin/daikin_brp072c.py
+++ b/pydaikin/daikin_brp072c.py
@@ -21,11 +21,11 @@ class DaikinBRP072C(DaikinBRP069):
             uuid = uuid3(NAMESPACE_OID, 'pydaikin')
         self._uuid = str(uuid).replace('-', '')
         self.headers = {"X-Daikin-uuid": self._uuid}
-        self._ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        self.ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
         # SSL_OP_LEGACY_SERVER_CONNECT, https://github.com/python/cpython/issues/89051
-        self._ssl_context.options |= 0x4
-        self._ssl_context.check_hostname = False
-        self._ssl_context.verify_mode = ssl.CERT_NONE
+        self.ssl_context.options |= 0x4
+        self.ssl_context.check_hostname = False
+        self.ssl_context.verify_mode = ssl.CERT_NONE
         self.base_url = f"https://{self.device_ip}"
 
     async def init(self):


### PR DESCRIPTION
- Fixes `headers` and `ssl_context` fields not being passed when making requests for a BRP072C device
- Seems like they were missed when refactoring code in this [commit](https://github.com/fredrike/pydaikin/commit/344bdec476561b639501d58e56116c74bd90af14#diff-ffa59b45e067df3cc76d27af3de4ab97de43476f9009e05d7999281ad213ae6d)
- Fixes Daikin devices failing in Home Assistant 2024.8 with the `ssl:default [[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled (_ssl.c:1000)]` error