### PR TITLE
Fix the regression from #pr13 for DaikinBRP069

### DIFF
--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -117,6 +117,9 @@ class DaikinBRP069(Appliance):
         'filter_sign_info': 'filter dirty',
     }
 
+    headers = None
+    ssl_context = None
+
     async def init(self):
         """Init status."""
         await self.auto_set_clock()


### PR DESCRIPTION
* Fixing the missing members `headers`,`ssl_context` on the class **DaikinBRP069**
* Resolve the issue https://github.com/home-assistant/core/issues/123550