### PR TITLE
Reduce the amount of concurrent requests for brp069

### DIFF
--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -117,6 +117,8 @@ class DaikinBRP069(Appliance):
         'filter_sign_info': 'filter dirty',
     }
 
+    MAX_CONCURRENT_REQUESTS = 1
+
     @staticmethod
     def parse_response(response_body):
         """Parse response from Daikin


### PR DESCRIPTION
The device cannot reliably handle more than one connection at a time.

Fixes https://github.com/fredrike/pydaikin/issues/22