### PR TITLE
Set instance INFO_RESOURCES instead of mutating class INFO_RESOURCES for brp069

### DIFF
--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -148,10 +148,13 @@ class DaikinBRP069(Appliance):
             await self.update_status(self.HTTP_RESOURCES)
 
         if self.support_energy_consumption:
-            self.INFO_RESOURCES += [  # pylint: disable=invalid-name
-                'aircon/get_day_power_ex',
-                'aircon/get_week_power',
-            ]
+            self.INFO_RESOURCES = (  # pylint: disable=invalid-name
+                self.INFO_RESOURCES
+                + [
+                    'aircon/get_day_power_ex',
+                    'aircon/get_week_power',
+                ]
+            )
 
     async def _update_settings(self, settings):
         """Update settings to set on Daikin device."""


### PR DESCRIPTION
I have 3 DaikinBRP072C based units, and found that logs indicated that each unit is making 3x calls for `aircon/get_week_power`.

```
2024-12-28 22:59:43.049 DEBUG (MainThread) [pydaikin.daikin_base] Updating ['aircon/get_sensor_info', 'aircon/get_control_info', 'aircon/get_week_power', 'aircon/get_week_power', 'aircon/get_week_power']
2024-12-28 22:59:43.049 DEBUG (MainThread) [pydaikin.daikin_base] Calling: https://daikin-dining/aircon/get_sensor_info {} [{'X-Daikin-uuid': 'xxx'}]
2024-12-28 22:59:43.051 DEBUG (MainThread) [pydaikin.daikin_base] Calling: https://daikin-dining/aircon/get_control_info {} [{'X-Daikin-uuid': 'xxx'}]
2024-12-28 22:59:43.051 DEBUG (MainThread) [pydaikin.daikin_base] Calling: https://daikin-dining/aircon/get_week_power {} [{'X-Daikin-uuid': 'xxx'}]
2024-12-28 22:59:43.051 DEBUG (MainThread) [pydaikin.daikin_base] Calling: https://daikin-dining/aircon/get_week_power {} [{'X-Daikin-uuid': 'xxx'}]
2024-12-28 22:59:43.051 DEBUG (MainThread) [pydaikin.daikin_base] Calling: https://daikin-dining/aircon/get_week_power {} [{'X-Daikin-uuid': 'xxx'}]
```

`DaikinBRP069`'s class variable `INFO_RESOURCES` is being mutated in `init`, and as a result each new instance of the class is adding duplicated entries to a shared list. 

Fixed by reassigning `INFO_RESOURCES` so it becomes a copy that's local to the instance. Logs after the fix:

```
2024-12-28 23:09:49.226 DEBUG (MainThread) [pydaikin.daikin_base] Updating ['aircon/get_sensor_info', 'aircon/get_control_info', 'aircon/get_week_power']
2024-12-28 23:09:49.227 DEBUG (MainThread) [pydaikin.daikin_base] Calling: https://daikin-dining/aircon/get_sensor_info {} [{'X-Daikin-uuid': 'xxx'}]
2024-12-28 23:09:49.228 DEBUG (MainThread) [pydaikin.daikin_base] Calling: https://daikin-dining/aircon/get_control_info {} [{'X-Daikin-uuid': 'xxx'}]
2024-12-28 23:09:49.228 DEBUG (MainThread) [pydaikin.daikin_base] Calling: https://daikin-dining/aircon/get_week_power {} [{'X-Daikin-uuid': 'xxx'}]
```

