### PR TITLE
Moved INFO_RESOURCES access to instance get method

### DIFF
--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -182,7 +182,7 @@ class Appliance(DaikinPowerMixin):  # pylint: disable=too-many-public-methods
     async def update_status(self, resources=None):
         """Update status from resources."""
         if resources is None:
-            resources = self.INFO_RESOURCES
+            resources = self.get_info_resources()
         resources = [
             resource
             for resource in resources
@@ -204,6 +204,9 @@ class Appliance(DaikinPowerMixin):  # pylint: disable=too-many-public-methods
             self.values.update_by_resource(resource, task.result())
 
         self._register_energy_consumption_history()
+
+    def get_info_resources(self):
+        return self.INFO_RESOURCES
 
     def show_values(self, only_summary=False):
         """Print values."""

--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -206,6 +206,7 @@ class Appliance(DaikinPowerMixin):  # pylint: disable=too-many-public-methods
         self._register_energy_consumption_history()
 
     def get_info_resources(self):
+        """Returns info_resources"""
         return self.INFO_RESOURCES
 
     def show_values(self, only_summary=False):

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -153,9 +153,8 @@ class DaikinBRP069(Appliance):
                 'aircon/get_day_power_ex',
                 'aircon/get_week_power',
             ]
-        
-        return self.INFO_RESOURCES
 
+        return self.INFO_RESOURCES
 
     async def _update_settings(self, settings):
         """Update settings to set on Daikin device."""

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -148,7 +148,7 @@ class DaikinBRP069(Appliance):
             await self.update_status(self.HTTP_RESOURCES)
 
     def get_info_resources(self):
-        """returns info_resources"""
+        """Returns info_resources"""
         if self.support_energy_consumption:
             return self.INFO_RESOURCES + [
                 'aircon/get_day_power_ex',

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -148,6 +148,7 @@ class DaikinBRP069(Appliance):
             await self.update_status(self.HTTP_RESOURCES)
 
     def get_info_resources(self):
+    """returns info_resources"""
         if self.support_energy_consumption:
             return self.INFO_RESOURCES + [
                 'aircon/get_day_power_ex',

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -148,7 +148,7 @@ class DaikinBRP069(Appliance):
             await self.update_status(self.HTTP_RESOURCES)
 
     def get_info_resources(self):
-    """returns info_resources"""
+        """returns info_resources"""
         if self.support_energy_consumption:
             return self.INFO_RESOURCES + [
                 'aircon/get_day_power_ex',

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -147,11 +147,15 @@ class DaikinBRP069(Appliance):
         else:
             await self.update_status(self.HTTP_RESOURCES)
 
+    def get_info_resources(self):
         if self.support_energy_consumption:
-            self.INFO_RESOURCES += [  # pylint: disable=invalid-name
+            return self.INFO_RESOURCES + [
                 'aircon/get_day_power_ex',
                 'aircon/get_week_power',
             ]
+        
+        return self.INFO_RESOURCES
+
 
     async def _update_settings(self, settings):
         """Update settings to set on Daikin device."""


### PR DESCRIPTION
In pydaikin/daikin_brp069.py INFO_RESOURCES is modified on init but meant to be a constant. If init is called multiple times this will cause the list of resources to grow.

I've split out access of info resources to an instance method to allow modification per instance based on state.

This fixes https://github.com/fredrike/pydaikin/issues/46