### PR TITLE
adds set_clock function for brp069 and fixed deprecated utcnow usage

### DIFF
--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 import socket
 from ssl import SSLContext
@@ -220,7 +220,7 @@ class Appliance(DaikinPowerMixin):  # pylint: disable=too-many-public-methods
     def log_sensors(self, file):
         """Log sensors to a file."""
         data = [
-            ('datetime', datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')),
+            ('datetime', datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')),
             ('in_temp', self.inside_temperature),
         ]
         if self.support_outside_temperature:
@@ -248,7 +248,7 @@ class Appliance(DaikinPowerMixin):  # pylint: disable=too-many-public-methods
     def show_sensors(self):
         """Print sensors."""
         data = [
-            datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S'),
+            datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S'),
             f'in_temp={int(self.inside_temperature)}°C',
         ]
         if self.support_outside_temperature:

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -1,7 +1,7 @@
 """Pydaikin appliance, represent a Daikin BRP069 device."""
 
-import logging
 from datetime import datetime, timezone
+import logging
 
 from .daikin_base import Appliance
 
@@ -260,7 +260,14 @@ class DaikinBRP069(Appliance):
         """Sets the clock on the AC to the current time"""
         now = datetime.now(timezone.utc)
         try:
-            await self._get_resource('common/notify_date_time', {"date=": now.strftime('%Y/%m/%d'), "zone": "GMT", "time":now.strftime('%H:%M:%S')})
+            await self._get_resource(
+                'common/notify_date_time',
+                {
+                    "date=": now.strftime('%Y/%m/%d'),
+                    "zone": "GMT",
+                    "time": now.strftime('%H:%M:%S'),
+                },
+            )
         except Exception as exc:  # pylint: disable=broad-except
             _LOGGER.error('Raised "%s" while setting internal clock', exc)
 

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -1,6 +1,7 @@
 """Pydaikin appliance, represent a Daikin BRP069 device."""
 
 import logging
+from datetime import datetime, timezone
 
 from .daikin_base import Appliance
 
@@ -254,6 +255,14 @@ class DaikinBRP069(Appliance):
 
     async def set_zone(self, zone_id, key, value):
         """Set zone status."""
+
+    async def set_clock(self):
+        """Sets the clock on the AC to the current time"""
+        now = datetime.now(timezone.utc)
+        try:
+            await self._get_resource('common/notify_date_time', {"date=": now.strftime('%Y/%m/%d'), "zone": "GMT", "time":now.strftime('%H:%M:%S')})
+        except Exception as exc:  # pylint: disable=broad-except
+            _LOGGER.error('Raised "%s" while setting internal clock', exc)
 
     async def auto_set_clock(self):
         """Tells the AC to auto-set its internal clock."""

--- a/pydaikin/power.py
+++ b/pydaikin/power.py
@@ -268,7 +268,10 @@ class DaikinPowerMixin:
             if min_power is not None and est_power > 0:
                 est_power = max(est_power, min_power)
 
-        if exp_diff_time and datetime.now(timezone.utc) > history[-1].datetime + exp_diff_time:
+        if (
+            exp_diff_time
+            and datetime.now(timezone.utc) > history[-1].datetime + exp_diff_time
+        ):
             # The power estimation was computed for a given duration
             # So if we exceed this duration we should return a zero power
             est_power = 0

--- a/pydaikin/power.py
+++ b/pydaikin/power.py
@@ -1,7 +1,7 @@
 """Pydaikin power mixin."""
 
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 
 ENERGY_CONSUMPTION_MAX_HISTORY = timedelta(hours=6)
@@ -99,7 +99,7 @@ class DaikinPowerMixin:
 
         for mode in (ATTR_TOTAL, ATTR_COOL, ATTR_HEAT):
             new_state = EnergyConsumptionState(
-                datetime=datetime.utcnow(),
+                datetime=datetime.now(timezone.utc),
                 first_state=not (self._energy_consumption_history[mode]),
                 today=self.energy_consumption(
                     mode=mode, time=TIME_TODAY, invalidate=False
@@ -131,7 +131,7 @@ class DaikinPowerMixin:
                             self._energy_consumption_history[mode]
                         )
                         if state.datetime
-                        < datetime.utcnow() - ENERGY_CONSUMPTION_MAX_HISTORY
+                        < datetime.now(timezone.utc) - ENERGY_CONSUMPTION_MAX_HISTORY
                     ),
                     default=len(self._energy_consumption_history[mode]),
                 )
@@ -268,7 +268,7 @@ class DaikinPowerMixin:
             if min_power is not None and est_power > 0:
                 est_power = max(est_power, min_power)
 
-        if exp_diff_time and datetime.utcnow() > history[-1].datetime + exp_diff_time:
+        if exp_diff_time and datetime.now(timezone.utc) > history[-1].datetime + exp_diff_time:
             # The power estimation was computed for a given duration
             # So if we exceed this duration we should return a zero power
             est_power = 0

--- a/pydaikin/values.py
+++ b/pydaikin/values.py
@@ -1,7 +1,7 @@
 """Smart container for appliance's data"""
 
 from collections.abc import MutableMapping
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 class ApplianceValues(MutableMapping):
@@ -62,13 +62,13 @@ class ApplianceValues(MutableMapping):
         self._last_update_by_resource = {
             resource: last_update
             for resource, last_update in self._last_update_by_resource.items()
-            if datetime.utcnow() - last_update < self.TTL
+            if datetime.now(timezone.utc) - last_update < self.TTL
         }
         return resource not in self._last_update_by_resource
 
     def update_by_resource(self, resource: str, data: dict):
         """Update the values and keep track of which resource provided them."""
         self._data.update(data)
-        self._last_update_by_resource[resource] = datetime.utcnow()
+        self._last_update_by_resource[resource] = datetime.now(timezone.utc)
         for k in data.keys():
             self._resource_by_key[k] = resource


### PR DESCRIPTION
I saw that you mentioned setting the clock via a service call and this would be the first step towards that.
https://github.com/home-assistant/core/issues/135136#issuecomment-2594654054
I also had the issue the I didn't have any energy infos anymore in home assistant until I set the clock again via the http request mentioned in the post above.

also while adding this I saw that the utcnow() function seems to be deprecated to I replaced it with the proper calls - sorry that this is now mixed together in this PR.

I'm also wondering about the "auto_set_clock" function... does it actually trigger an auto set in the daikin device? the http call to the device actually just returns the time in the machine but does nothing additional with it (like checking if its the current time)