### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,10 +9,10 @@ authors = [
 ]
 name = "pydaikin"
 version = "2.15.0"
+license = "GPL-3.0-or-later"
 description = "Python Daikin HVAC appliances interface"
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Application Frameworks",
   "Topic :: Home Automation",


### PR DESCRIPTION
Setuptools `77.0` added support for [PEP 639](https://peps.python.org/pep-0639/) license expressions.
I believe, based on the `LICENSE` file,  `GPL-3.0-or-later` is the correct identifier. The alternative would be `GPL-3.0-only`.
https://github.com/fredrike/pydaikin/blob/c6d80b53f1854f0122016b92f39030e705ca0f4b/LICENSE#L637-L640

https://spdx.org/licenses/GPL-3.0-or-later.html
https://spdx.org/licenses/GPL-3.0-only.html