### PR TITLE
fix: SSL WRONG_SIGNATURE_TYPE

### DIFF
--- a/pydaikin/daikin_brp072c.py
+++ b/pydaikin/daikin_brp072c.py
@@ -41,7 +41,7 @@ class DaikinBRP072C(DaikinBRP069):
         try:
             self.ssl_context.set_ciphers("DEFAULT:@SECLEVEL=0")
         except Exception:
-            pass # Some things won't support SECLEVEL
+            pass  # Some things won't support SECLEVEL
         self.base_url = f"https://{self.device_ip}"
 
     async def init(self):

--- a/pydaikin/daikin_brp072c.py
+++ b/pydaikin/daikin_brp072c.py
@@ -40,8 +40,10 @@ class DaikinBRP072C(DaikinBRP069):
         # Fixes SSL WRONG_SIGNATURE_TYPE error
         try:
             self.ssl_context.set_ciphers("DEFAULT:@SECLEVEL=0")
-        except Exception:
-            pass  # Some things won't support SECLEVEL
+        except ssl.SSLError:
+            # Some things won't support SECLEVEL, and the cipher setting then
+            # shouldn't matter
+            pass
         self.base_url = f"https://{self.device_ip}"
 
     async def init(self):

--- a/pydaikin/daikin_brp072c.py
+++ b/pydaikin/daikin_brp072c.py
@@ -37,6 +37,11 @@ class DaikinBRP072C(DaikinBRP069):
         self.ssl_context.options |= ssl.OP_LEGACY_SERVER_CONNECT
         self.ssl_context.check_hostname = False
         self.ssl_context.verify_mode = ssl.CERT_NONE
+        # Fixes SSL WRONG_SIGNATURE_TYPE error
+        try:
+            self.ssl_context.set_ciphers("DEFAULT:@SECLEVEL=0")
+        except Exception:
+            pass # Some things won't support SECLEVEL
         self.base_url = f"https://{self.device_ip}"
 
     async def init(self):


### PR DESCRIPTION
Allows pydaikin to still work with units that are still using legacy TLS ciphers and settings.

