### PR TITLE
Fix BRP084 crash when outdoor temp sensor returns null

### DIFF
--- a/pydaikin/daikin_brp084.py
+++ b/pydaikin/daikin_brp084.py
@@ -294,6 +294,23 @@ class DaikinBRP084(Appliance):
 
         return 'off'  # Default return value
 
+    def _safe_extract(self, response: dict, *keys) -> Optional[str]:
+        """Extract a value from the response, returning None if not found."""
+        try:
+            return self.find_value_by_pn(response, *keys)
+        except DaikinException:
+            return None
+
+    def _safe_hex_temp(self, response: dict, path_key: str, divisor: int = 2) -> str:
+        """Extract a temperature value, returning '--' if missing or null."""
+        try:
+            raw = self.find_value_by_pn(response, *self.get_path(path_key))
+            if raw is not None:
+                return str(self.hex_to_temp(raw, divisor))
+        except DaikinException:
+            pass
+        return "--"
+
     async def init(self):
         """Initialize the device and fetch initial state."""
         # Only update if values haven't been populated yet (e.g., by factory detection)
@@ -325,9 +342,12 @@ class DaikinBRP084(Appliance):
 
         # Extract basic info
         try:
-            # Get MAC address
+            # Get MAC address and firmware version
             mac = self.find_value_by_pn(response, *self.get_path("mac_address"))
             self.values['mac'] = mac
+            self.values['ver'] = self._safe_extract(
+                response, "/dsiot/edge.adp_i", "adp_i", "ver"
+            )
 
             # Get power state
             is_off = self.find_value_by_pn(response, *self.get_path("power")) == "00"
@@ -339,11 +359,7 @@ class DaikinBRP084(Appliance):
             self.values['mode'] = 'off' if is_off else self.MODE_MAP[mode_value]
 
             # Get temperatures
-            self.values['otemp'] = str(
-                self.hex_to_temp(
-                    self.find_value_by_pn(response, *self.get_path("outdoor_temp"))
-                )
-            )
+            self.values['otemp'] = self._safe_hex_temp(response, "outdoor_temp")
 
             self.values['htemp'] = str(
                 self.hex_to_temp(

--- a/tests/test_daikin_brp084.py
+++ b/tests/test_daikin_brp084.py
@@ -411,3 +411,192 @@ def test_support_humidity(values, expected):
     device = DaikinBRP084('127.0.0.1', session=mock_session)
     device.values.update(values)
     assert device.support_humidity is expected
+
+
+@pytest.mark.asyncio
+async def test_null_outdoor_temp(aresponses, client_session):
+    """Test that a null outdoor temperature is handled gracefully."""
+    mock_response = {
+        "responses": [
+            {
+                "fr": "/dsiot/edge/adr_0100.dgc_status",
+                "pc": {
+                    "pn": "dgc_status",
+                    "pch": [
+                        {
+                            "pn": "e_1002",
+                            "pch": [
+                                {"pn": "e_A002", "pch": [{"pn": "p_01", "pv": "01"}]},
+                                {
+                                    "pn": "e_3001",
+                                    "pch": [
+                                        {"pn": "p_01", "pv": "0200"},
+                                        {"pn": "p_02", "pv": "32"},
+                                        {"pn": "p_09", "pv": "0A00"},
+                                        {"pn": "p_05", "pv": "000000"},
+                                        {"pn": "p_06", "pv": "000000"},
+                                    ],
+                                },
+                                {
+                                    "pn": "e_A00B",
+                                    "pch": [
+                                        {"pn": "p_01", "pv": "18"},
+                                        {"pn": "p_02", "pv": "3c"},
+                                    ],
+                                },
+                            ],
+                        }
+                    ],
+                },
+                "rsc": 2000,
+            },
+            {
+                "fr": "/dsiot/edge/adr_0200.dgc_status",
+                "pc": {
+                    "pn": "dgc_status",
+                    "pch": [
+                        {
+                            "pn": "e_1003",
+                            "pch": [
+                                {
+                                    "pn": "e_A00D",
+                                    "pch": [{"pn": "p_01", "pv": None}],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "rsc": 2000,
+            },
+            {
+                "fr": "/dsiot/edge/adr_0100.i_power.week_power",
+                "pc": {
+                    "pn": "week_power",
+                    "pch": [
+                        {"pn": "today_runtime", "pv": "0"},
+                        {"pn": "datas", "pv": [0, 0, 0, 0, 0, 0, 0]},
+                    ],
+                },
+                "rsc": 2000,
+            },
+            {
+                "fr": "/dsiot/edge.adp_i",
+                "pc": {"pn": "adp_i", "pch": [{"pn": "mac", "pv": "112233445566"}]},
+                "rsc": 2000,
+            },
+        ]
+    }
+
+    aresponses.add(
+        path_pattern="/dsiot/multireq",
+        method_pattern="POST",
+        response=aresponses.Response(
+            status=200,
+            text=json.dumps(mock_response),
+            headers={"Content-Type": "application/json"},
+        ),
+    )
+
+    device = DaikinBRP084('ip', session=client_session)
+    await device.init()
+
+    assert device.values.get('otemp') == '--'
+    assert device.values.get('mode') == 'cool'
+    assert device.values.get('htemp') == '24.0'
+
+
+@pytest.mark.asyncio
+async def test_firmware_version_extraction(aresponses, client_session):
+    """Test that firmware version is extracted from adapter info."""
+    mock_response = {
+        "responses": [
+            {
+                "fr": "/dsiot/edge/adr_0100.dgc_status",
+                "pc": {
+                    "pn": "dgc_status",
+                    "pch": [
+                        {
+                            "pn": "e_1002",
+                            "pch": [
+                                {"pn": "e_A002", "pch": [{"pn": "p_01", "pv": "01"}]},
+                                {
+                                    "pn": "e_3001",
+                                    "pch": [
+                                        {"pn": "p_01", "pv": "0200"},
+                                        {"pn": "p_02", "pv": "32"},
+                                        {"pn": "p_09", "pv": "0A00"},
+                                        {"pn": "p_05", "pv": "000000"},
+                                        {"pn": "p_06", "pv": "000000"},
+                                    ],
+                                },
+                                {
+                                    "pn": "e_A00B",
+                                    "pch": [
+                                        {"pn": "p_01", "pv": "18"},
+                                        {"pn": "p_02", "pv": "3c"},
+                                    ],
+                                },
+                            ],
+                        }
+                    ],
+                },
+                "rsc": 2000,
+            },
+            {
+                "fr": "/dsiot/edge/adr_0200.dgc_status",
+                "pc": {
+                    "pn": "dgc_status",
+                    "pch": [
+                        {
+                            "pn": "e_1003",
+                            "pch": [
+                                {
+                                    "pn": "e_A00D",
+                                    "pch": [{"pn": "p_01", "pv": "22"}],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "rsc": 2000,
+            },
+            {
+                "fr": "/dsiot/edge/adr_0100.i_power.week_power",
+                "pc": {
+                    "pn": "week_power",
+                    "pch": [
+                        {"pn": "today_runtime", "pv": "120"},
+                        {"pn": "datas", "pv": [100, 200, 300, 400, 500, 600, 700]},
+                    ],
+                },
+                "rsc": 2000,
+            },
+            {
+                "fr": "/dsiot/edge.adp_i",
+                "pc": {
+                    "pn": "adp_i",
+                    "pch": [
+                        {"pn": "mac", "pv": "112233445566"},
+                        {"pn": "ver", "pv": "3_12_3"},
+                    ],
+                },
+                "rsc": 2000,
+            },
+        ]
+    }
+
+    aresponses.add(
+        path_pattern="/dsiot/multireq",
+        method_pattern="POST",
+        response=aresponses.Response(
+            status=200,
+            text=json.dumps(mock_response),
+            headers={"Content-Type": "application/json"},
+        ),
+    )
+
+    device = DaikinBRP084('ip', session=client_session)
+    await device.init()
+
+    assert device.values.get('ver') == '3_12_3'
+    assert device.values.get('mac') == '112233445566'


### PR DESCRIPTION
## Summary

- Fix `TypeError` crash in `DaikinBRP084.update_status()` when outdoor temperature sensor returns `null`
- Extract firmware version (`ver`) from adapter info response for Home Assistant device registry

## Problem

I have a brand new **Daikin Alira X** (model **RXM50WVMA / FTXM50WVMA**) with built-in WiFi (firmware **3.12.3**, `data_model_code: 26`). This unit uses the dsiot protocol (`/dsiot/multireq`), which is handled by `DaikinBRP084`.

The unit was completely unreachable from Home Assistant's Daikin integration, despite being online and fully controllable via the Daikin Mobile Controller app.

### Root Cause

The outdoor unit's temperature sensor (`e_1003` → `e_A00D` → `p_01`) returns `null` in the dsiot response when the outdoor unit hasn't started reporting temperature data (e.g. when the AC is off or just booting up). Here's the relevant portion of the device response:

```json
{
    "pn": "e_A00D",
    "pt": 1,
    "pch": [
        {
            "pn": "p_01",
            "pt": 3,
            "pv": null,
            ...
        }
    ]
}
```

This `null` value flows through `find_value_by_pn()` and is passed to `hex_to_temp(None)`, which calls `int(None[:2], 16)` and throws a `TypeError`.

The exception propagation chain:
1. `hex_to_temp(None)` → `TypeError: 'NoneType' object is not subscriptable`
2. `TypeError` is not caught by `except DaikinException` in `update_status()`
3. Propagates to `DaikinFactory.__init__()` where it's caught by `except Exception`
4. Factory concludes "Not a firmware 2.8.0 device" and falls back to `DaikinBRP069`
5. BRP069 fails because the device doesn't serve `/common/basic_info` (returns 404)
6. Falls back to `DaikinAirBase`, which also fails
7. **Device cannot be connected at all**

## Fix

### 1. Null-safe outdoor temperature parsing

Wrap the outdoor temperature extraction in a try/except with a `None` check, falling back to `"--"`. This is consistent with how indoor humidity is already handled a few lines below in the same method:

```python
# Before (crashes on null):
self.values['otemp'] = str(
    self.hex_to_temp(
        self.find_value_by_pn(response, *self.get_path("outdoor_temp"))
    )
)

# After (handles null gracefully):
try:
    otemp_raw = self.find_value_by_pn(response, *self.get_path("outdoor_temp"))
    if otemp_raw is not None:
        self.values['otemp'] = str(self.hex_to_temp(otemp_raw))
    else:
        self.values['otemp'] = "--"
except DaikinException:
    self.values['otemp'] = "--"
```

### 2. Extract firmware version from adapter info

The adapter info response (`/dsiot/edge.adp_i`) contains the firmware version but it was never stored in `self.values`. Home Assistant's `entity.py` reads `device.values.get("ver")` to display `sw_version` in the device registry. Added extraction so the firmware version appears correctly.

## Testing

Tested against a live Daikin Alira X (RXM50WVMA/FTXM50WVMA) at 192.168.3.48 running firmware 3.12.3:

| Test | Result |
|------|--------|
| `DaikinFactory` detection | PASS - correctly identifies as `DaikinBRP084` |
| `update_status()` with null outdoor temp | PASS - returns `"--"` instead of crashing |
| `update_status()` with valid outdoor temp | PASS - returns correct value (e.g. `18.5`) |
| Firmware version extraction | PASS - `ver: "3_12_3"` stored in values |
| All 5 HVAC modes (cool/heat/auto/fan/dry) | PASS |
| Power on/off | PASS |
| All 7 fan rates (auto/quiet/1-5) | PASS |
| All 4 swing modes (off/vertical/horizontal/both) | PASS |
| Temperature control | PASS |
| Rapid consecutive status updates | PASS |
| `represent()` for all HA attributes | PASS |
| All base class properties | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)