### PR TITLE
Add new skyfi hot water appliances

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following Daikin WiFi modules are currently supported:
 * **BRP072B/Cxx** - Requires HTTPS access and an authentication key
 * **BRP084** - Devices with firmware version 2.8.0 (uses a different API structure)
 * **SKYFi** - Uses a different protocol and requires a password
+* **BRP15B61 (AirBase) heat pump hot water** - Uses the local AirBase hot water API
 
 ## Quick Start
 

--- a/bin/pydaikin
+++ b/bin/pydaikin
@@ -58,10 +58,10 @@ parser.add_argument(
 parser.add_argument('-k', '--key', help='unit\'s key (only used by BRP072Cxx devices)')
 
 parser.add_argument(
-    '--hot-water',
-    '--airbase-hot-water',
-    action='store_true',
-    help='use the AirBase hot water API',
+    "--hot-water",
+    "--airbase-hot-water",
+    action="store_true",
+    help="use the AirBase hot water API",
 )
 
 settings = parser.add_argument_group('device settings', 'Modify paramaters of a device')
@@ -104,92 +104,92 @@ settings.add_argument(
 )
 
 hot_water_settings = parser.add_argument_group(
-    'AirBase hot water settings', 'Modify parameters of an AirBase hot water device'
+    "AirBase hot water settings", "Modify parameters of an AirBase hot water device"
 )
 
 hot_water_settings.add_argument(
-    '--power', choices=('on', 'off'), help='turn the hot water system on or off'
+    "--power", choices=("on", "off"), help="turn the hot water system on or off"
 )
 
 hot_water_settings.add_argument(
-    '--boost', choices=('on', 'off'), help='turn hot water boost on or off'
+    "--boost", choices=("on", "off"), help="turn hot water boost on or off"
 )
 
 hot_water_settings.add_argument(
-    '--vacation', choices=('on', 'off'), help='turn hot water vacation mode on or off'
+    "--vacation", choices=("on", "off"), help="turn hot water vacation mode on or off"
 )
 
 hot_water_settings.add_argument(
-    '--vacation-days', type=int, help='set hot water vacation days'
+    "--vacation-days", type=int, help="set hot water vacation days"
 )
 
 hot_water_settings.add_argument(
-    '--boil-level',
+    "--boil-level",
     type=int,
-    help='set hot water boil level, where 0 is auto and 1-6 are manual',
+    help="set hot water boil level, where 0 is auto and 1-6 are manual",
 )
 
 hot_water_settings.add_argument(
-    '--drive-program',
-    '--drive-p',
-    help='set active hot water drive program, 1-6 or set_01..program_1_and_2',
+    "--drive-program",
+    "--drive-p",
+    help="set active hot water drive program, 1-6 or set_01..program_1_and_2",
 )
 
 hot_water_settings.add_argument(
-    '--program1-start',
-    '--drive-p1s',
-    help='set hot water program 1 start time as HH:MM or slot 0-47',
+    "--program1-start",
+    "--drive-p1s",
+    help="set hot water program 1 start time as HH:MM or slot 0-47",
 )
 
 hot_water_settings.add_argument(
-    '--program1-end',
-    '--drive-p1e',
-    help='set hot water program 1 end time as HH:MM or slot 0-47',
+    "--program1-end",
+    "--drive-p1e",
+    help="set hot water program 1 end time as HH:MM or slot 0-47",
 )
 
 hot_water_settings.add_argument(
-    '--program2-start',
-    '--drive-p2s',
-    help='set hot water program 2 start time as HH:MM or slot 0-47',
+    "--program2-start",
+    "--drive-p2s",
+    help="set hot water program 2 start time as HH:MM or slot 0-47",
 )
 
 hot_water_settings.add_argument(
-    '--program2-end',
-    '--drive-p2e',
-    help='set hot water program 2 end time as HH:MM or slot 0-47',
+    "--program2-end",
+    "--drive-p2e",
+    help="set hot water program 2 end time as HH:MM or slot 0-47",
 )
 
 
 SETTING_ARGS = (
-    ('mode', 'mode', None),
-    ('temp', 'stemp', str),
-    ('humidity', 'shum', str),
-    ('fan', 'f_rate', None),
-    ('direction', 'f_dir', None),
-    ('away', 'en_hol', None),
-    ('power', 'pow', None),
-    ('boost', 'boost', None),
-    ('vacation', 'vacation', None),
-    ('vacation_days', 'vacation_days', None),
-    ('boil_level', 'boil_level', None),
-    ('drive_program', 'drive_program', None),
-    ('program1_start', 'program_1_start', None),
-    ('program1_end', 'program_1_end', None),
-    ('program2_start', 'program_2_start', None),
-    ('program2_end', 'program_2_end', None),
+    ("mode", "mode", None),
+    ("temp", "stemp", str),
+    ("humidity", "shum", str),
+    ("fan", "f_rate", None),
+    ("direction", "f_dir", None),
+    ("away", "en_hol", None),
+    ("power", "pow", None),
+    ("boost", "boost", None),
+    ("vacation", "vacation", None),
+    ("vacation_days", "vacation_days", None),
+    ("boil_level", "boil_level", None),
+    ("drive_program", "drive_program", None),
+    ("program1_start", "program_1_start", None),
+    ("program1_end", "program_1_end", None),
+    ("program2_start", "program_2_start", None),
+    ("program2_end", "program_2_end", None),
 )
 
 HOT_WATER_ARGS = (
-    'power',
-    'boost',
-    'vacation',
-    'vacation_days',
-    'boil_level',
-    'drive_program',
-    'program1_start',
-    'program1_end',
-    'program2_start',
-    'program2_end',
+    "power",
+    "boost",
+    "vacation",
+    "vacation_days",
+    "boil_level",
+    "drive_program",
+    "program1_start",
+    "program1_end",
+    "program2_start",
+    "program2_end",
 )
 
 
@@ -238,7 +238,7 @@ async def main():  # pylint: disable=too-many-branches
             hot_water=args.hot_water,
         )
         if hot_water_args_used(args) and not isinstance(daikin, DaikinAirBaseHotWater):
-            parser.error('hot water settings require an AirBase hot water device')
+            parser.error("hot water settings require an AirBase hot water device")
 
         if not _settings:
             daikin.show_values(not args.all)

--- a/bin/pydaikin
+++ b/bin/pydaikin
@@ -8,6 +8,7 @@ from contextlib import nullcontext
 from aiohttp import ClientError
 
 from pydaikin import discovery  # pylint: disable=cyclic-import
+from pydaikin.daikin_airbase_hotwater import DaikinAirBaseHotWater
 from pydaikin.daikin_brp069 import (  # noqa: E0611; pylint: disable=no-name-in-module
     DaikinBRP069 as appliance,
 )
@@ -56,6 +57,13 @@ parser.add_argument(
 
 parser.add_argument('-k', '--key', help='unit\'s key (only used by BRP072Cxx devices)')
 
+parser.add_argument(
+    '--hot-water',
+    '--airbase-hot-water',
+    action='store_true',
+    help='use the AirBase hot water API',
+)
+
 settings = parser.add_argument_group('device settings', 'Modify paramaters of a device')
 
 settings.add_argument(
@@ -93,6 +101,32 @@ settings.add_argument(
     help='Verbose level (none: critical, v: error, vv: warning, vvv: info, vvvv: debug)',
     action='count',
     default=0,
+)
+
+hot_water_settings = parser.add_argument_group(
+    'AirBase hot water settings', 'Modify parameters of an AirBase hot water device'
+)
+
+hot_water_settings.add_argument(
+    '--power', choices=('on', 'off'), help='turn the hot water system on or off'
+)
+
+hot_water_settings.add_argument(
+    '--boost', choices=('on', 'off'), help='turn hot water boost on or off'
+)
+
+hot_water_settings.add_argument(
+    '--vacation', choices=('on', 'off'), help='turn hot water vacation mode on or off'
+)
+
+hot_water_settings.add_argument(
+    '--vacation-days', type=int, help='set hot water vacation days'
+)
+
+hot_water_settings.add_argument(
+    '--boil-level',
+    type=int,
+    help='set hot water boil level, where 0 is auto and 1-6 are manual',
 )
 
 
@@ -133,10 +167,43 @@ async def main():  # pylint: disable=too-many-branches
     if args.away:
         _settings.update({"en_hol": args.away})
 
+    if args.power:
+        _settings.update({"pow": args.power})
+
+    if args.boost:
+        _settings.update({"boost": args.boost})
+
+    if args.vacation:
+        _settings.update({"vacation": args.vacation})
+
+    if args.vacation_days is not None:
+        _settings.update({"vacation_days": args.vacation_days})
+
+    if args.boil_level is not None:
+        _settings.update({"boil_level": args.boil_level})
+
+    hot_water_args_used = any(
+        value is not None
+        for value in [
+            args.power,
+            args.boost,
+            args.vacation,
+            args.vacation_days,
+            args.boil_level,
+        ]
+    )
+
     if args.list:
         await list_all_devices()
     else:
-        daikin = await DaikinFactory(args.device, key=args.key, password=args.password)
+        daikin = await DaikinFactory(
+            args.device,
+            key=args.key,
+            password=args.password,
+            hot_water=args.hot_water,
+        )
+        if hot_water_args_used and not isinstance(daikin, DaikinAirBaseHotWater):
+            parser.error('hot water settings require an AirBase hot water device')
 
         if not _settings:
             daikin.show_values(not args.all)

--- a/bin/pydaikin
+++ b/bin/pydaikin
@@ -129,6 +129,84 @@ hot_water_settings.add_argument(
     help='set hot water boil level, where 0 is auto and 1-6 are manual',
 )
 
+hot_water_settings.add_argument(
+    '--drive-program',
+    '--drive-p',
+    help='set active hot water drive program, 1-6 or set_01..program_1_and_2',
+)
+
+hot_water_settings.add_argument(
+    '--program1-start',
+    '--drive-p1s',
+    help='set hot water program 1 start time as HH:MM or slot 0-47',
+)
+
+hot_water_settings.add_argument(
+    '--program1-end',
+    '--drive-p1e',
+    help='set hot water program 1 end time as HH:MM or slot 0-47',
+)
+
+hot_water_settings.add_argument(
+    '--program2-start',
+    '--drive-p2s',
+    help='set hot water program 2 start time as HH:MM or slot 0-47',
+)
+
+hot_water_settings.add_argument(
+    '--program2-end',
+    '--drive-p2e',
+    help='set hot water program 2 end time as HH:MM or slot 0-47',
+)
+
+
+SETTING_ARGS = (
+    ('mode', 'mode', None),
+    ('temp', 'stemp', str),
+    ('humidity', 'shum', str),
+    ('fan', 'f_rate', None),
+    ('direction', 'f_dir', None),
+    ('away', 'en_hol', None),
+    ('power', 'pow', None),
+    ('boost', 'boost', None),
+    ('vacation', 'vacation', None),
+    ('vacation_days', 'vacation_days', None),
+    ('boil_level', 'boil_level', None),
+    ('drive_program', 'drive_program', None),
+    ('program1_start', 'program_1_start', None),
+    ('program1_end', 'program_1_end', None),
+    ('program2_start', 'program_2_start', None),
+    ('program2_end', 'program_2_end', None),
+)
+
+HOT_WATER_ARGS = (
+    'power',
+    'boost',
+    'vacation',
+    'vacation_days',
+    'boil_level',
+    'drive_program',
+    'program1_start',
+    'program1_end',
+    'program2_start',
+    'program2_end',
+)
+
+
+def settings_from_args(args):
+    """Build device settings from parsed arguments."""
+    device_settings = {}
+    for arg_name, setting_name, converter in SETTING_ARGS:
+        value = getattr(args, arg_name)
+        if value is not None:
+            device_settings[setting_name] = converter(value) if converter else value
+    return device_settings
+
+
+def hot_water_args_used(args):
+    """Return True when any hot water setting was supplied."""
+    return any(getattr(args, arg_name) is not None for arg_name in HOT_WATER_ARGS)
+
 
 async def main():  # pylint: disable=too-many-branches
     """Main function."""
@@ -148,50 +226,7 @@ async def main():  # pylint: disable=too-many-branches
             ][args.verbose]
         )
 
-    _settings = {}
-    if args.mode:
-        _settings.update({"mode": args.mode})
-
-    if args.temp:
-        _settings.update({"stemp": str(args.temp)})
-
-    if args.humidity:
-        _settings.update({"shum": str(args.humidity)})
-
-    if args.fan:
-        _settings.update({"f_rate": args.fan})
-
-    if args.direction:
-        _settings.update({"f_dir": args.direction})
-
-    if args.away:
-        _settings.update({"en_hol": args.away})
-
-    if args.power:
-        _settings.update({"pow": args.power})
-
-    if args.boost:
-        _settings.update({"boost": args.boost})
-
-    if args.vacation:
-        _settings.update({"vacation": args.vacation})
-
-    if args.vacation_days is not None:
-        _settings.update({"vacation_days": args.vacation_days})
-
-    if args.boil_level is not None:
-        _settings.update({"boil_level": args.boil_level})
-
-    hot_water_args_used = any(
-        value is not None
-        for value in [
-            args.power,
-            args.boost,
-            args.vacation,
-            args.vacation_days,
-            args.boil_level,
-        ]
-    )
+    _settings = settings_from_args(args)
 
     if args.list:
         await list_all_devices()
@@ -202,7 +237,7 @@ async def main():  # pylint: disable=too-many-branches
             password=args.password,
             hot_water=args.hot_water,
         )
-        if hot_water_args_used and not isinstance(daikin, DaikinAirBaseHotWater):
+        if hot_water_args_used(args) and not isinstance(daikin, DaikinAirBaseHotWater):
             parser.error('hot water settings require an AirBase hot water device')
 
         if not _settings:

--- a/pydaikin/daikin_airbase_hotwater.py
+++ b/pydaikin/daikin_airbase_hotwater.py
@@ -1,0 +1,440 @@
+"""Pydaikin appliance for Daikin AirBase heat pump hot water devices."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+import re
+from typing import Any, Optional
+
+from aiohttp import ClientSession
+
+from .daikin_base import Appliance
+from .exceptions import DaikinException
+
+_LOGGER = logging.getLogger(__name__)
+
+StatusValue = bool | int | float | str | None
+
+
+class AirBaseHotWaterError(DaikinException):
+    """Daikin AirBase hot water base exception."""
+
+
+class AirBaseHotWaterResponseError(AirBaseHotWaterError):
+    """Raised when the AirBase hot water device returns an invalid response."""
+
+
+class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-methods
+    """Daikin class for AirBase heat pump hot water devices.
+
+    These controllers use the BRP15B61/AirBase-style local API: HTTP on port 80,
+    no SkyFi password, and paths under ``/skyfi``.
+    """
+
+    GET_UNIT_INFO = "skyfi/hotwater/get_unit_info"
+    SET_CONTROL_INFO = "skyfi/hotwater/set_control_info"
+
+    HTTP_RESOURCES = [GET_UNIT_INFO]
+    INFO_RESOURCES = HTTP_RESOURCES
+
+    MAX_VACATION_DAYS = 365
+    MAX_CONCURRENT_REQUESTS = 1
+
+    TRANSLATIONS = {
+        "pow": {
+            "0": "off",
+            "1": "on",
+        },
+        "boost": {
+            "0": "off",
+            "1": "on",
+        },
+        "vacation": {
+            "0": "off",
+            "1": "on",
+        },
+        "mode": {
+            "auto": "auto",
+            "manual": "manual",
+            "off": "off",
+        },
+    }
+
+    VALUES_SUMMARY = [
+        "mode",
+        "pow",
+        "boost",
+        "vacation",
+        "vacation_days",
+        "boil_level",
+        "temp_tank",
+        "temp_set",
+        "temp_outside",
+    ]
+
+    VALUES_TRANSLATION = {
+        "pow": "power",
+        "temp_set": "target temp",
+        "temp_tank": "tank temp",
+        "temp_outside": "outside temp",
+        "boil_level": "boil level",
+        "vacation_days": "vacation days",
+    }
+
+    _BOOL_CONTROL_FIELDS = {"pow", "boost", "vacation"}
+    _INT_CONTROL_FIELDS = {"boil_level", "vacation_days"}
+    _READ_ONLY_FIELDS = {"temp_set", "temp_tank", "temp_outside"}
+    _VALID_CONTROL_FIELDS = _BOOL_CONTROL_FIELDS | _INT_CONTROL_FIELDS
+    _CONTROL_ALIASES = {
+        "power": "pow",
+    }
+
+    def __init__(
+        self,
+        device_id: str,
+        session: ClientSession | None = None,
+    ) -> None:
+        """Init Daikin AirBase heat pump hot water device."""
+        super().__init__(device_id, session)
+
+    async def init(self):
+        """Init status."""
+        if not self.values:
+            await self.update_status(self.HTTP_RESOURCES)
+        if not self.values:
+            raise DaikinException("Empty values.")
+
+    @staticmethod
+    def parse_response(response_body):
+        """Parse response from the AirBase hot water API."""
+        _LOGGER.debug("Parsing %s", response_body)
+        response = dict(
+            (match.group(1), match.group(2))
+            for match in re.finditer(r"(\w+)=([^=]*)(?:,|$)", response_body)
+        )
+        if "ret" not in response:
+            raise AirBaseHotWaterResponseError("missing 'ret' field in response")
+        ret = response.pop("ret")
+        if ret != "OK":
+            raise AirBaseHotWaterResponseError(f"ret={ret!r}")
+        boil_level = response.get("boil_level")
+        if boil_level is not None:
+            try:
+                DaikinAirBaseHotWater._validate_int_range(
+                    "boil_level", boil_level, minimum=0, maximum=6
+                )
+            except ValueError as exc:
+                raise AirBaseHotWaterResponseError(str(exc)) from exc
+            response["mode"] = "auto" if boil_level == "0" else "manual"
+        return response
+
+    async def get_status(self) -> dict[str, StatusValue]:
+        """Fetch and return typed hot water status data."""
+        self.values.invalidate_resource(self.GET_UNIT_INFO)
+        await self.update_status(self.HTTP_RESOURCES)
+        return {
+            "power": self._to_bool(self.values.get("pow", invalidate=False), "pow"),
+            "boost": self._to_bool(self.values.get("boost", invalidate=False), "boost"),
+            "vacation": self._to_bool(
+                self.values.get("vacation", invalidate=False), "vacation"
+            ),
+            "vacation_days": self._to_int(
+                self.values.get("vacation_days", invalidate=False), "vacation_days"
+            ),
+            "boil_level": self._to_int(
+                self.values.get("boil_level", invalidate=False), "boil_level"
+            ),
+            "mode": self.represent("mode")[1] if "mode" in self.values else None,
+            "temp_set": self._to_float(
+                self.values.get("temp_set", invalidate=False), "temp_set"
+            ),
+            "temp_tank": self._to_float(
+                self.values.get("temp_tank", invalidate=False), "temp_tank"
+            ),
+            "temp_outside": self._to_float(
+                self.values.get("temp_outside", invalidate=False), "temp_outside"
+            ),
+        }
+
+    async def set(self, settings):
+        """Set settings on Daikin AirBase hot water device."""
+        params = self._normalize_control_params(settings)
+        if not params:
+            return
+
+        _LOGGER.debug(
+            "Sending request to %s with params: %s", self.SET_CONTROL_INFO, params
+        )
+        await self._get_resource(self.SET_CONTROL_INFO, params)
+        self.values.update_by_resource(self.GET_UNIT_INFO, params)
+        if "boil_level" in params:
+            self.values["mode"] = "auto" if params["boil_level"] == "0" else "manual"
+
+    async def set_holiday(self, mode):
+        """Set holiday mode."""
+
+    async def set_advanced_mode(self, mode, value):
+        """Set advanced mode."""
+
+    async def set_streamer(self, mode):
+        """Set streamer mode."""
+
+    async def set_control(self, **kwargs: Any) -> None:
+        """Set writable hot water control parameters."""
+        await self.set(kwargs)
+
+    async def set_boil_level(self, level: int) -> None:
+        """Set boil level, where 0 is auto and 1-6 are manual levels."""
+        await self.set({"boil_level": level})
+
+    async def set_mode_auto(self) -> None:
+        """Set automatic boil mode."""
+        await self.set({"mode": "auto"})
+
+    async def set_mode_manual(self, level: int) -> None:
+        """Set manual boil mode level from 1 to 6."""
+        level = self._validate_int_range(
+            "manual boil level", level, minimum=1, maximum=6
+        )
+        await self.set({"mode": "manual", "boil_level": level})
+
+    async def set_boost(self, mode) -> None:
+        """Turn boost mode on or off."""
+        await self.set({"boost": mode})
+
+    async def set_vacation(self, mode) -> None:
+        """Turn vacation mode on or off."""
+        await self.set({"vacation": mode})
+
+    async def set_vacation_days(self, days: int) -> None:
+        """Set vacation days from 0 to MAX_VACATION_DAYS."""
+        await self.set({"vacation_days": days})
+
+    async def set_power(self, mode) -> None:
+        """Turn the hot water system on or off."""
+        await self.set({"pow": mode})
+
+    async def set_zone(self, zone_id, key, value):
+        """Set zone status."""
+
+    @property
+    def support_away_mode(self):
+        """Return False as hot water vacation mode is separate from away mode."""
+        return False
+
+    @property
+    def support_fan_rate(self):
+        """Return False as hot water devices do not have a fan setting."""
+        return False
+
+    @property
+    def support_swing_mode(self):
+        """Return False as hot water devices do not have swing modes."""
+        return False
+
+    @property
+    def support_humidity(self) -> bool:
+        """Return False as hot water devices do not have a humidity sensor."""
+        return False
+
+    @property
+    def humidity(self) -> Optional[float]:
+        """Return None as hot water devices do not have a humidity sensor."""
+        return None
+
+    @property
+    def support_outside_temperature(self):
+        """Return True if the device reports an outside temperature."""
+        return "temp_outside" in self.values and self.values["temp_outside"] != "-"
+
+    @property
+    def outside_temperature(self) -> Optional[float]:
+        """Return current outside temperature."""
+        return self._parse_number("temp_outside")
+
+    @property
+    def inside_temperature(self) -> Optional[float]:
+        """Return current tank temperature for sensor compatibility."""
+        return self._parse_number("temp_tank")
+
+    @property
+    def tank_temperature(self) -> Optional[float]:
+        """Return current hot water tank temperature."""
+        return self._parse_number("temp_tank")
+
+    @property
+    def target_temperature(self) -> Optional[float]:
+        """Return current hot water target temperature."""
+        return self._parse_number("temp_set")
+
+    def show_sensors(self):
+        """Print hot water sensors."""
+        data = [
+            datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+        ]
+        if self.tank_temperature is not None:
+            data.append(f"tank_temp={self.tank_temperature:.0f}°C")
+        if self.target_temperature is not None:
+            data.append(f"target_temp={self.target_temperature:.0f}°C")
+        if self.support_outside_temperature and self.outside_temperature is not None:
+            data.append(f"out_temp={self.outside_temperature:.0f}°C")
+        print("  ".join(data))
+
+    def log_sensors(self, file):
+        """Log hot water sensors to a file."""
+        data = [
+            ("datetime", datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")),
+            ("tank_temp", self.tank_temperature),
+            ("target_temp", self.target_temperature),
+        ]
+        if self.support_outside_temperature:
+            data.append(("out_temp", self.outside_temperature))
+        if file.tell() == 0:
+            file.write(",".join(k for k, _ in data))
+            file.write("\n")
+        file.write(",".join(str(v) for _, v in data))
+        file.write("\n")
+        file.flush()
+
+    @classmethod
+    def _normalize_control_params(cls, params: dict[str, Any]) -> dict[str, str]:
+        """Validate and convert control parameters for the device API."""
+        normalized: dict[str, str] = {}
+
+        params = {
+            cls._CONTROL_ALIASES.get(key, key): value for key, value in params.items()
+        }
+
+        mode = params.pop("mode", None)
+        if mode is not None:
+            cls._normalize_mode(mode, params, normalized)
+
+        for key, value in params.items():
+            if key in cls._READ_ONLY_FIELDS:
+                raise ValueError(f"{key} is read-only and cannot be set")
+            if key not in cls._VALID_CONTROL_FIELDS:
+                raise ValueError(f"Unsupported control parameter: {key}")
+
+            if key in cls._BOOL_CONTROL_FIELDS:
+                normalized[key] = cls._normalize_bool_control(key, value)
+            elif key == "boil_level":
+                normalized[key] = str(
+                    cls._validate_int_range(key, value, minimum=0, maximum=6)
+                )
+            elif key == "vacation_days":
+                normalized[key] = str(
+                    cls._validate_int_range(
+                        key,
+                        value,
+                        minimum=0,
+                        maximum=cls.MAX_VACATION_DAYS,
+                    )
+                )
+
+        return normalized
+
+    @classmethod
+    def _normalize_mode(
+        cls,
+        mode: Any,
+        params: dict[str, Any],
+        normalized: dict[str, str],
+    ) -> None:
+        """Normalize mode into writable hot water controls."""
+        if mode == "off":
+            normalized["pow"] = "0"
+        elif mode == "auto":
+            if "boil_level" in params:
+                boil_level = cls._validate_int_range(
+                    "boil_level", params["boil_level"], minimum=0, maximum=6
+                )
+                if boil_level != 0:
+                    raise ValueError("auto mode requires boil_level 0")
+                params.pop("boil_level")
+            normalized["pow"] = "1"
+            normalized["boil_level"] = "0"
+        elif mode == "manual":
+            if "boil_level" not in params:
+                raise ValueError("manual mode requires boil_level")
+            normalized["pow"] = "1"
+        else:
+            raise ValueError(f"Unsupported mode for AirBase hot water: {mode}")
+
+    @staticmethod
+    def _normalize_bool_control(key: str, value: Any) -> str:
+        """Normalize a bool-like control value to 0 or 1."""
+        if isinstance(value, bool):
+            return "1" if value else "0"
+        if isinstance(value, int) and value in (0, 1):
+            return str(value)
+        if isinstance(value, str):
+            if value in {"0", "1"}:
+                return value
+            if value in {"off", "on"}:
+                return "1" if value == "on" else "0"
+        raise ValueError(f"{key} must be a boolean or 0/1")
+
+    @staticmethod
+    def _validate_int_range(
+        key: str,
+        value: Any,
+        *,
+        minimum: int,
+        maximum: int,
+    ) -> int:
+        """Validate an integer falls inside an inclusive range."""
+        if isinstance(value, bool):
+            raise ValueError(f"{key} must be an integer")
+
+        try:
+            int_value = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{key} must be an integer") from exc
+
+        if int_value < minimum or int_value > maximum:
+            raise ValueError(f"{key} must be between {minimum} and {maximum}")
+        return int_value
+
+    @classmethod
+    def _to_bool(cls, value: str | None, key: str) -> bool | None:
+        """Convert a 0/1 status value to bool."""
+        if cls._is_missing(value):
+            return None
+        if value == "1":
+            return True
+        if value == "0":
+            return False
+        raise AirBaseHotWaterResponseError(f"{key} must be 0 or 1, got {value!r}")
+
+    @classmethod
+    def _to_int(cls, value: str | None, key: str) -> int | None:
+        """Convert a status value to int."""
+        if cls._is_missing(value):
+            return None
+        try:
+            return int(value)
+        except ValueError as exc:
+            raise AirBaseHotWaterResponseError(
+                f"{key} must be an integer, got {value!r}"
+            ) from exc
+
+    @classmethod
+    def _to_float(cls, value: str | None, key: str) -> float | None:
+        """Convert a status value to float."""
+        if cls._is_missing(value):
+            return None
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise AirBaseHotWaterResponseError(
+                f"{key} must be a float, got {value!r}"
+            ) from exc
+
+    @staticmethod
+    def _is_missing(value: str | None) -> bool:
+        """Return True when a status field is absent or intentionally blank."""
+        return value in (None, "", "-")
+
+
+AirBaseHotWaterDevice = DaikinAirBaseHotWater

--- a/pydaikin/daikin_airbase_hotwater.py
+++ b/pydaikin/daikin_airbase_hotwater.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, time, timezone
 import logging
 import re
 from typing import Any, Optional
@@ -39,7 +39,12 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
     INFO_RESOURCES = HTTP_RESOURCES
 
     MAX_VACATION_DAYS = 365
+    DRIVE_TIME_SLOT_MINUTES = 30
+    DRIVE_TIME_SLOTS_PER_DAY = 24 * 60 // DRIVE_TIME_SLOT_MINUTES
     MAX_CONCURRENT_REQUESTS = 1
+    PROGRAM_1 = 5
+    PROGRAM_1_AND_2 = 6
+    PROGRAM_2 = PROGRAM_1_AND_2
 
     TRANSLATIONS = {
         "pow": {
@@ -59,6 +64,14 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
             "manual": "manual",
             "off": "off",
         },
+        "drive_p": {
+            "1": "set_01",
+            "2": "set_02",
+            "3": "set_03",
+            "4": "set_04",
+            "5": "program_1",
+            "6": "program_1_and_2",
+        },
     }
 
     VALUES_SUMMARY = [
@@ -68,9 +81,14 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
         "vacation",
         "vacation_days",
         "boil_level",
+        "drive_p",
         "temp_tank",
         "temp_set",
         "temp_outside",
+        "drive_p1s",
+        "drive_p1e",
+        "drive_p2s",
+        "drive_p2e",
     ]
 
     VALUES_TRANSLATION = {
@@ -80,14 +98,82 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
         "temp_outside": "outside temp",
         "boil_level": "boil level",
         "vacation_days": "vacation days",
+        "drive_p": "drive program",
+        "drive_p1s": "program 1 start",
+        "drive_p1e": "program 1 end",
+        "drive_p2s": "program 2 start",
+        "drive_p2e": "program 2 end",
     }
 
+    _DRIVE_PROGRAM_ALIASES = {
+        "set_01": 1,
+        "set_1": 1,
+        "set01": 1,
+        "set1": 1,
+        "set_02": 2,
+        "set_2": 2,
+        "set02": 2,
+        "set2": 2,
+        "set_03": 3,
+        "set_3": 3,
+        "set03": 3,
+        "set3": 3,
+        "set_04": 4,
+        "set_4": 4,
+        "set04": 4,
+        "set4": 4,
+        "program_1": PROGRAM_1,
+        "program1": PROGRAM_1,
+        "prog_1": PROGRAM_1,
+        "prog1": PROGRAM_1,
+        "drive_p1": PROGRAM_1,
+        "program_1_and_2": PROGRAM_1_AND_2,
+        "programs_1_and_2": PROGRAM_1_AND_2,
+        "program_1_2": PROGRAM_1_AND_2,
+        "programs_1_2": PROGRAM_1_AND_2,
+        "prog_1_and_2": PROGRAM_1_AND_2,
+        "progs_1_and_2": PROGRAM_1_AND_2,
+        "prog_1_2": PROGRAM_1_AND_2,
+        "progs_1_2": PROGRAM_1_AND_2,
+        "drive_p1_p2": PROGRAM_1_AND_2,
+        "program_2": PROGRAM_1_AND_2,
+        "program2": PROGRAM_1_AND_2,
+        "prog_2": PROGRAM_1_AND_2,
+        "prog2": PROGRAM_1_AND_2,
+        "drive_p2": PROGRAM_1_AND_2,
+    }
+    _DRIVE_PROGRAM_FIELD = "drive_p"
+    _DRIVE_TIME_FIELDS = {"drive_p1s", "drive_p1e", "drive_p2s", "drive_p2e"}
+    _DRIVE_TIME_STATUS_FIELDS = {
+        "drive_p1s": "program_1_start",
+        "drive_p1e": "program_1_end",
+        "drive_p2s": "program_2_start",
+        "drive_p2e": "program_2_end",
+    }
     _BOOL_CONTROL_FIELDS = {"pow", "boost", "vacation"}
-    _INT_CONTROL_FIELDS = {"boil_level", "vacation_days"}
+    _INT_CONTROL_FIELDS = {
+        "boil_level",
+        "vacation_days",
+        _DRIVE_PROGRAM_FIELD,
+    } | _DRIVE_TIME_FIELDS
     _READ_ONLY_FIELDS = {"temp_set", "temp_tank", "temp_outside"}
     _VALID_CONTROL_FIELDS = _BOOL_CONTROL_FIELDS | _INT_CONTROL_FIELDS
     _CONTROL_ALIASES = {
         "power": "pow",
+        "drive_program": "drive_p",
+        "drive_program_selection": "drive_p",
+        "program1_start": "drive_p1s",
+        "program1_end": "drive_p1e",
+        "program2_start": "drive_p2s",
+        "program2_end": "drive_p2e",
+        "program_1_start": "drive_p1s",
+        "program_1_end": "drive_p1e",
+        "program_2_start": "drive_p2s",
+        "program_2_end": "drive_p2e",
+        "drive_program_1_start": "drive_p1s",
+        "drive_program_1_end": "drive_p1e",
+        "drive_program_2_start": "drive_p2s",
+        "drive_program_2_end": "drive_p2e",
     }
 
     def __init__(
@@ -127,13 +213,29 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
             except ValueError as exc:
                 raise AirBaseHotWaterResponseError(str(exc)) from exc
             response["mode"] = "auto" if boil_level == "0" else "manual"
+        drive_program = response.get("drive_p")
+        if drive_program is not None:
+            try:
+                DaikinAirBaseHotWater._normalize_drive_program(drive_program)
+            except ValueError as exc:
+                raise AirBaseHotWaterResponseError(str(exc)) from exc
+        for key in DaikinAirBaseHotWater._DRIVE_TIME_FIELDS:
+            drive_time = response.get(key)
+            if not DaikinAirBaseHotWater._is_missing(drive_time):
+                try:
+                    DaikinAirBaseHotWater._validate_drive_time_slot(key, drive_time)
+                except ValueError as exc:
+                    raise AirBaseHotWaterResponseError(str(exc)) from exc
         return response
 
     async def get_status(self) -> dict[str, StatusValue]:
         """Fetch and return typed hot water status data."""
         self.values.invalidate_resource(self.GET_UNIT_INFO)
         await self.update_status(self.HTTP_RESOURCES)
-        return {
+        drive_program_value = self._to_drive_program_value(
+            self.values.get("drive_p", invalidate=False)
+        )
+        status: dict[str, StatusValue] = {
             "power": self._to_bool(self.values.get("pow", invalidate=False), "pow"),
             "boost": self._to_bool(self.values.get("boost", invalidate=False), "boost"),
             "vacation": self._to_bool(
@@ -145,6 +247,11 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
             "boil_level": self._to_int(
                 self.values.get("boil_level", invalidate=False), "boil_level"
             ),
+            "drive_p": drive_program_value,
+            "drive_program": self._drive_program_label(drive_program_value),
+            "set_program": self._drive_set_program(drive_program_value),
+            "manual_program_1": self._manual_program_1_enabled(drive_program_value),
+            "manual_program_2": self._manual_program_2_enabled(drive_program_value),
             "mode": self.represent("mode")[1] if "mode" in self.values else None,
             "temp_set": self._to_float(
                 self.values.get("temp_set", invalidate=False), "temp_set"
@@ -156,12 +263,18 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
                 self.values.get("temp_outside", invalidate=False), "temp_outside"
             ),
         }
+        for source, target in self._DRIVE_TIME_STATUS_FIELDS.items():
+            raw_value = self.values.get(source, invalidate=False)
+            status[source] = self._to_drive_time_slot(raw_value, source)
+            status[target] = self._to_drive_time(raw_value, source)
+        return status
 
     async def set(self, settings):
         """Set settings on Daikin AirBase hot water device."""
         params = self._normalize_control_params(settings)
         if not params:
             return
+        self._validate_drive_program_selection(params)
 
         _LOGGER.debug(
             "Sending request to %s with params: %s", self.SET_CONTROL_INFO, params
@@ -215,6 +328,42 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
         """Turn the hot water system on or off."""
         await self.set({"pow": mode})
 
+    async def set_drive_program_selection(self, program: Any) -> None:
+        """Set the active drive program.
+
+        ``program_1_and_2`` enables both manually configured programs. Program 2
+        cannot be active by itself.
+        """
+        await self.set({"drive_p": program})
+
+    async def set_drive_set_program(self, program: int) -> None:
+        """Set one of the mutually exclusive fixed drive programs 1-4."""
+        program = self._validate_int_range("set program", program, minimum=1, maximum=4)
+        await self.set_drive_program_selection(program)
+
+    async def set_drive_program(self, program: int, start: Any, end: Any) -> None:
+        """Set a drive program start and end time.
+
+        Args:
+            program: Drive program number, either 1 or 2.
+            start: Start time as a 0-47 half-hour slot or HH:MM string.
+            end: End time as a 0-47 half-hour slot or HH:MM string.
+        """
+        if program == 1:
+            await self.set({"drive_p1s": start, "drive_p1e": end})
+        elif program == 2:
+            await self.set({"drive_p2s": start, "drive_p2e": end})
+        else:
+            raise ValueError("drive program must be 1 or 2")
+
+    async def set_drive_program_1(self, start: Any, end: Any) -> None:
+        """Set drive program 1 start and end time."""
+        await self.set_drive_program(1, start, end)
+
+    async def set_drive_program_2(self, start: Any, end: Any) -> None:
+        """Set drive program 2 start and end time."""
+        await self.set_drive_program(2, start, end)
+
     async def set_zone(self, zone_id, key, value):
         """Set zone status."""
 
@@ -267,6 +416,24 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
     def target_temperature(self) -> Optional[float]:
         """Return current hot water target temperature."""
         return self._parse_number("temp_set")
+
+    def represent(self, key):
+        """Return translated value from key."""
+        if key in self._DRIVE_TIME_FIELDS:
+            k = self.VALUES_TRANSLATION.get(key, key)
+            return (k, self._to_drive_time(self.values.get(key), key))
+        return super().represent(key)
+
+    def _validate_drive_program_selection(self, params: dict[str, str]) -> None:
+        """Validate program 2 is only selected after program 1 is active."""
+        if params.get("drive_p") != str(self.PROGRAM_1_AND_2):
+            return
+
+        current_program = self.values.get("drive_p", invalidate=False)
+        if current_program is None:
+            return
+        if current_program not in {str(self.PROGRAM_1), str(self.PROGRAM_1_AND_2)}:
+            raise ValueError("program_1_and_2 requires program_1 to be selected first")
 
     def show_sensors(self):
         """Print hot water sensors."""
@@ -331,6 +498,10 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
                         maximum=cls.MAX_VACATION_DAYS,
                     )
                 )
+            elif key == cls._DRIVE_PROGRAM_FIELD:
+                normalized[key] = str(cls._normalize_drive_program(value))
+            elif key in cls._DRIVE_TIME_FIELDS:
+                normalized[key] = str(cls._normalize_drive_time(key, value))
 
         return normalized
 
@@ -397,6 +568,57 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
         return int_value
 
     @classmethod
+    def _normalize_drive_time(cls, key: str, value: Any) -> int:
+        """Normalize a drive program time to a half-hour slot."""
+        if isinstance(value, time):
+            return cls._time_parts_to_drive_slot(key, value.hour, value.minute)
+        if isinstance(value, str):
+            if re.fullmatch(r"\d+", value):
+                return cls._validate_drive_time_slot(key, value)
+            match = re.fullmatch(r"(\d{1,2}):(\d{2})", value)
+            if match:
+                return cls._time_parts_to_drive_slot(
+                    key,
+                    int(match.group(1)),
+                    int(match.group(2)),
+                )
+            raise ValueError(f"{key} must be a 0-47 slot or HH:MM time")
+        return cls._validate_drive_time_slot(key, value)
+
+    @classmethod
+    def _validate_drive_time_slot(cls, key: str, value: Any) -> int:
+        """Validate a drive program time slot."""
+        return cls._validate_int_range(
+            key, value, minimum=0, maximum=cls.DRIVE_TIME_SLOTS_PER_DAY - 1
+        )
+
+    @classmethod
+    def _normalize_drive_program(cls, value: Any) -> int:
+        """Normalize a drive program selector to its API value."""
+        if isinstance(value, str):
+            normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+            if normalized in cls._DRIVE_PROGRAM_ALIASES:
+                return cls._DRIVE_PROGRAM_ALIASES[normalized]
+        return cls._validate_int_range("drive_p", value, minimum=1, maximum=6)
+
+    @classmethod
+    def _time_parts_to_drive_slot(cls, key: str, hour: int, minute: int) -> int:
+        """Convert HH:MM parts to a half-hour drive time slot."""
+        if hour < 0 or hour > 23:
+            raise ValueError(f"{key} hour must be between 0 and 23")
+        if minute % cls.DRIVE_TIME_SLOT_MINUTES != 0 or minute < 0 or minute > 59:
+            raise ValueError(f"{key} must use 30 minute increments")
+        return (hour * 60 + minute) // cls.DRIVE_TIME_SLOT_MINUTES
+
+    @classmethod
+    def _drive_time_slot_to_time(cls, value: Any, key: str) -> str:
+        """Convert a half-hour drive time slot to HH:MM."""
+        slot = cls._validate_drive_time_slot(key, value)
+        minutes = slot * cls.DRIVE_TIME_SLOT_MINUTES
+        hour, minute = divmod(minutes, 60)
+        return f"{hour:02d}:{minute:02d}"
+
+    @classmethod
     def _to_bool(cls, value: str | None, key: str) -> bool | None:
         """Convert a 0/1 status value to bool."""
         if cls._is_missing(value):
@@ -430,6 +652,72 @@ class DaikinAirBaseHotWater(Appliance):  # pylint: disable=too-many-public-metho
             raise AirBaseHotWaterResponseError(
                 f"{key} must be a float, got {value!r}"
             ) from exc
+
+    @classmethod
+    def _to_drive_time_slot(cls, value: str | None, key: str) -> int | None:
+        """Convert a status drive program time to its raw half-hour slot."""
+        if cls._is_missing(value):
+            return None
+        try:
+            return cls._validate_drive_time_slot(key, value)
+        except ValueError as exc:
+            raise AirBaseHotWaterResponseError(str(exc)) from exc
+
+    @classmethod
+    def _to_drive_time(cls, value: str | None, key: str) -> str | None:
+        """Convert a status drive program time to HH:MM."""
+        if cls._is_missing(value):
+            return None
+        try:
+            return cls._drive_time_slot_to_time(value, key)
+        except ValueError as exc:
+            raise AirBaseHotWaterResponseError(str(exc)) from exc
+
+    @classmethod
+    def _to_drive_program_value(cls, value: str | None) -> int | None:
+        """Convert a status drive program selector to its raw value."""
+        if cls._is_missing(value):
+            return None
+        try:
+            return cls._normalize_drive_program(value)
+        except ValueError as exc:
+            raise AirBaseHotWaterResponseError(str(exc)) from exc
+
+    @classmethod
+    def _to_drive_program(cls, value: str | None) -> str | None:
+        """Convert a status drive program selector to its generic label."""
+        if cls._is_missing(value):
+            return None
+        raw_value = cls._to_drive_program_value(value)
+        return cls._drive_program_label(raw_value)
+
+    @classmethod
+    def _drive_program_label(cls, raw_value: int | None) -> str | None:
+        """Return the generic label for a drive program selector."""
+        if raw_value is None:
+            return None
+        return cls.daikin_to_human("drive_p", str(raw_value))
+
+    @classmethod
+    def _drive_set_program(cls, raw_value: int | None) -> int | None:
+        """Return selected fixed set program number, if any."""
+        if raw_value is None or raw_value > 4:
+            return None
+        return raw_value
+
+    @classmethod
+    def _manual_program_1_enabled(cls, raw_value: int | None) -> bool | None:
+        """Return whether manual program 1 is selected."""
+        if raw_value is None:
+            return None
+        return raw_value in {cls.PROGRAM_1, cls.PROGRAM_1_AND_2}
+
+    @classmethod
+    def _manual_program_2_enabled(cls, raw_value: int | None) -> bool | None:
+        """Return whether manual program 2 is selected."""
+        if raw_value is None:
+            return None
+        return raw_value == cls.PROGRAM_1_AND_2
 
     @staticmethod
     def _is_missing(value: str | None) -> bool:

--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -271,7 +271,7 @@ class Appliance(DaikinPowerMixin):
         for key in keys:
             if key in self.values:
                 k, val = self.represent(key)
-                print(f"{k : >20}: {val}")
+                print(f"{k: >20}: {val}")
 
     def log_sensors(self, file):
         """Log sensors to a file."""

--- a/pydaikin/factory.py
+++ b/pydaikin/factory.py
@@ -8,6 +8,7 @@ from aiohttp import ClientSession
 from aiohttp.web_exceptions import HTTPNotFound
 
 from .daikin_airbase import DaikinAirBase
+from .daikin_airbase_hotwater import DaikinAirBaseHotWater
 from .daikin_base import Appliance
 from .daikin_brp069 import DaikinBRP069
 from .daikin_brp072c import DaikinBRP072C
@@ -30,12 +31,14 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
         await instance.__init__(*a, **kw)
         return instance._generated_object
 
+    # pylint: disable-next=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-statements
     async def __init__(
         self,
         device_id: str,
         session: Optional[ClientSession] = None,
         password: str = None,
         key: str = None,
+        hot_water: bool = False,
         **kwargs,
     ) -> None:
         """Factory to init the corresponding Daikin class."""
@@ -44,7 +47,11 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
         device_ip, device_port = self._extract_ip_port(device_id)
         obj = None
 
-        if password:
+        if hot_water:
+            obj = DaikinAirBaseHotWater(device_ip, session)
+            if device_port and device_port != 80:
+                obj.base_url = f"http://{device_ip}:{device_port}"
+        elif password:
             obj = DaikinSkyFi(device_ip, session, password)
         elif key:
             obj = DaikinBRP072C(
@@ -82,6 +89,24 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
                     raise DaikinException("Empty Values.")
             except (HTTPNotFound, DaikinException) as err:
                 _LOGGER.debug("Not a BRP069 device: %s", err)
+                obj = None
+        # Try AirBase hot water
+        if not obj:
+            try:
+                _LOGGER.debug("Trying connection to AirBase hot water")
+                obj = DaikinAirBaseHotWater(device_ip, session)
+
+                # If we have a specific port from discovery, set it in the base_url
+                if device_port and device_port != 80:
+                    _LOGGER.debug(
+                        "Using custom port %s for AirBase hot water", device_port
+                    )
+                    obj.base_url = f"http://{device_ip}:{device_port}"
+                await obj.update_status(obj.HTTP_RESOURCES)
+                if not obj.values:
+                    raise DaikinException("Empty Values.")
+            except (HTTPNotFound, DaikinException) as err:
+                _LOGGER.debug("Not an AirBase hot water device: %s", err)
                 obj = None
         # Try AirBase
         if not obj:

--- a/tests/test_airbase_hotwater.py
+++ b/tests/test_airbase_hotwater.py
@@ -1,0 +1,312 @@
+"""Tests for Daikin AirBase heat pump hot water devices."""
+
+import re
+from unittest.mock import MagicMock
+
+from aiohttp import ClientSession
+import pytest
+import pytest_asyncio
+
+from pydaikin.daikin_airbase_hotwater import (
+    AirBaseHotWaterResponseError,
+    DaikinAirBaseHotWater,
+)
+
+
+@pytest_asyncio.fixture
+async def client_session():
+    client_session = ClientSession()
+    yield client_session
+    await client_session.close()
+
+
+@pytest.mark.asyncio
+async def test_init(aresponses, client_session):
+    """Test fetching and representing hot water status."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response=(
+            "ret=OK,pow=1,boost=0,vacation=0,vacation_days=3,"
+            "temp_set=63.0,temp_tank=56,temp_outside=13,boil_level=0"
+        ),
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    await device.init()
+
+    assert device.values.get("pow", invalidate=False) == "1"
+    assert device.values.get("mode", invalidate=False) == "auto"
+    assert device.represent("pow") == ("power", "on")
+    assert device.represent("mode") == ("mode", "auto")
+    assert device.represent("temp_tank") == ("tank temp", "56")
+    assert device.tank_temperature == 56.0
+    assert device.target_temperature == 63.0
+    assert device.outside_temperature == 13.0
+    assert device.support_away_mode is False
+    assert device.support_fan_rate is False
+    assert device.support_swing_mode is False
+    assert device.support_humidity is False
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_typed_values(aresponses, client_session):
+    """Test fetching typed hot water status."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response=(
+            "ret=OK,pow=1,boost=0,vacation=0,vacation_days=3,"
+            "temp_set=63.0,temp_tank=56,temp_outside=13,boil_level=0"
+        ),
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    assert await device.get_status() == {
+        "power": True,
+        "boost": False,
+        "vacation": False,
+        "vacation_days": 3,
+        "boil_level": 0,
+        "mode": "auto",
+        "temp_set": 63.0,
+        "temp_tank": 56.0,
+        "temp_outside": 13.0,
+    }
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_manual_mode(aresponses, client_session):
+    """Test that non-zero boil levels are manual mode."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response="ret=OK,pow=1,boost=1,vacation=0,vacation_days=0,boil_level=4",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    await device.init()
+
+    assert device.values.get("boil_level", invalidate=False) == "4"
+    assert device.values.get("mode", invalidate=False) == "manual"
+    assert device.represent("mode") == ("mode", "manual")
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_power_off_represents_mode_as_off(aresponses, client_session):
+    """Test powered off hot water devices follow the existing mode=off convention."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response="ret=OK,pow=0,boost=0,vacation=0,vacation_days=0,boil_level=4",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    await device.init()
+
+    assert device.values.get("mode", invalidate=False) == "manual"
+    assert device.represent("mode") == ("mode", "off")
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_get_status_rejects_bad_ret(aresponses, client_session):
+    """Test bad status responses raise a clear exception."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response="ret=NG",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    with pytest.raises(AirBaseHotWaterResponseError):
+        await device.get_status()
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_get_status_rejects_invalid_boil_level(aresponses, client_session):
+    """Test invalid boil levels in status responses raise a clear exception."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response="ret=OK,boil_level=7",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    with pytest.raises(AirBaseHotWaterResponseError):
+        await device.get_status()
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_set_control_sends_normalized_params(aresponses, client_session):
+    """Test setting multiple writable controls."""
+    aresponses.add(
+        path_pattern=re.compile(
+            r"/skyfi/hotwater/set_control_info\?"
+            r"(?=.*boil_level=6)(?=.*boost=1)(?=.*vacation=0)"
+        ),
+        method_pattern="GET",
+        match_querystring=True,
+        response="ret=OK",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    await device.set_control(boil_level=6, boost=True, vacation=0)
+
+    assert device.values.get("boil_level", invalidate=False) == "6"
+    assert device.values.get("boost", invalidate=False) == "1"
+    assert device.values.get("vacation", invalidate=False) == "0"
+    assert device.values.get("mode", invalidate=False) == "manual"
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_set_mode_auto_sends_power_and_boil_level(aresponses, client_session):
+    """Test setting auto mode powers on and sets boil level to auto."""
+    aresponses.add(
+        path_pattern=re.compile(
+            r"/skyfi/hotwater/set_control_info\?(?=.*pow=1)(?=.*boil_level=0)"
+        ),
+        method_pattern="GET",
+        match_querystring=True,
+        response="ret=OK",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    await device.set({"mode": "auto"})
+
+    assert device.values.get("pow", invalidate=False) == "1"
+    assert device.values.get("boil_level", invalidate=False) == "0"
+    assert device.values.get("mode", invalidate=False) == "auto"
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_set_mode_off_sends_power_off(aresponses, client_session):
+    """Test setting mode off uses the existing CLI mode convention."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/set_control_info?pow=0",
+        method_pattern="GET",
+        match_querystring=True,
+        response="ret=OK",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    await device.set({"mode": "off"})
+
+    assert device.values.get("pow", invalidate=False) == "0"
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_helper_methods(aresponses, client_session):
+    """Test helper setters call the control endpoint."""
+    for expected_path in [
+        re.compile(r"/skyfi/hotwater/set_control_info\?(?=.*pow=1)(?=.*boil_level=0)"),
+        re.compile(r"/skyfi/hotwater/set_control_info\?(?=.*pow=1)(?=.*boil_level=3)"),
+        "/skyfi/hotwater/set_control_info?boost=0",
+        "/skyfi/hotwater/set_control_info?vacation=1",
+        "/skyfi/hotwater/set_control_info?pow=0",
+    ]:
+        aresponses.add(
+            path_pattern=expected_path,
+            method_pattern="GET",
+            match_querystring=True,
+            response="ret=OK",
+        )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    await device.set_mode_auto()
+    await device.set_mode_manual(3)
+    await device.set_boost(False)
+    await device.set_vacation(True)
+    await device.set_power(False)
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_vacation_days_helper(aresponses, client_session):
+    """Test vacation days helper validation and request."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/set_control_info?vacation_days=14",
+        method_pattern="GET",
+        match_querystring=True,
+        response="ret=OK",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    await device.set_vacation_days(14)
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+def test_set_control_validation():
+    """Test invalid control values are rejected before HTTP requests."""
+    device = DaikinAirBaseHotWater("ip", session=MagicMock())
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"temp_set": 60})
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"boil_level": 7})
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"mode": "manual"})
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params(
+            {"mode": "auto", "boil_level": 3}
+        )
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"vacation_days": 366})
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"pow": 2})
+
+    assert DaikinAirBaseHotWater._normalize_control_params(
+        {"power": "on", "boost": "off", "vacation_days": 14}
+    ) == {
+        "pow": "1",
+        "boost": "0",
+        "vacation_days": "14",
+    }
+
+    assert device.humidity is None

--- a/tests/test_airbase_hotwater.py
+++ b/tests/test_airbase_hotwater.py
@@ -28,7 +28,8 @@ async def test_init(aresponses, client_session):
         method_pattern="GET",
         response=(
             "ret=OK,pow=1,boost=0,vacation=0,vacation_days=3,"
-            "temp_set=63.0,temp_tank=56,temp_outside=13,boil_level=0"
+            "temp_set=63.0,temp_tank=56,temp_outside=13,boil_level=0,drive_p=5,"
+            "drive_p1s=42,drive_p1e=14,drive_p2s=22,drive_p2e=28"
         ),
     )
 
@@ -41,6 +42,11 @@ async def test_init(aresponses, client_session):
     assert device.represent("pow") == ("power", "on")
     assert device.represent("mode") == ("mode", "auto")
     assert device.represent("temp_tank") == ("tank temp", "56")
+    assert device.represent("drive_p") == ("drive program", "program_1")
+    assert device.represent("drive_p1s") == ("program 1 start", "21:00")
+    assert device.represent("drive_p1e") == ("program 1 end", "07:00")
+    assert device.represent("drive_p2s") == ("program 2 start", "11:00")
+    assert device.represent("drive_p2e") == ("program 2 end", "14:00")
     assert device.tank_temperature == 56.0
     assert device.target_temperature == 63.0
     assert device.outside_temperature == 13.0
@@ -61,7 +67,8 @@ async def test_get_status_returns_typed_values(aresponses, client_session):
         method_pattern="GET",
         response=(
             "ret=OK,pow=1,boost=0,vacation=0,vacation_days=3,"
-            "temp_set=63.0,temp_tank=56,temp_outside=13,boil_level=0"
+            "temp_set=63.0,temp_tank=56,temp_outside=13,boil_level=0,drive_p=5,"
+            "drive_p1s=42,drive_p1e=14,drive_p2s=22,drive_p2e=28"
         ),
     )
 
@@ -73,11 +80,71 @@ async def test_get_status_returns_typed_values(aresponses, client_session):
         "vacation": False,
         "vacation_days": 3,
         "boil_level": 0,
+        "drive_p": 5,
+        "drive_program": "program_1",
+        "set_program": None,
+        "manual_program_1": True,
+        "manual_program_2": False,
         "mode": "auto",
         "temp_set": 63.0,
         "temp_tank": 56.0,
         "temp_outside": 13.0,
+        "drive_p1s": 42,
+        "drive_p1e": 14,
+        "drive_p2s": 22,
+        "drive_p2e": 28,
+        "program_1_start": "21:00",
+        "program_1_end": "07:00",
+        "program_2_start": "11:00",
+        "program_2_end": "14:00",
     }
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_manual_program_pair(aresponses, client_session):
+    """Test drive_p=6 represents manual programs 1 and 2 together."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response="ret=OK,pow=1,boil_level=0,drive_p=6",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    status = await device.get_status()
+
+    assert status["drive_p"] == 6
+    assert status["drive_program"] == "program_1_and_2"
+    assert status["set_program"] is None
+    assert status["manual_program_1"] is True
+    assert status["manual_program_2"] is True
+    assert device.represent("drive_p") == ("drive program", "program_1_and_2")
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_set_program(aresponses, client_session):
+    """Test set programs are represented as mutually exclusive selections."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response="ret=OK,pow=1,boil_level=0,drive_p=2",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    status = await device.get_status()
+
+    assert status["drive_p"] == 2
+    assert status["drive_program"] == "set_02"
+    assert status["set_program"] == 2
+    assert status["manual_program_1"] is False
+    assert status["manual_program_2"] is False
 
     aresponses.assert_all_requests_matched()
     aresponses.assert_no_unused_routes()
@@ -161,12 +228,51 @@ async def test_get_status_rejects_invalid_boil_level(aresponses, client_session)
 
 
 @pytest.mark.asyncio
+async def test_get_status_rejects_invalid_drive_program_time(
+    aresponses, client_session
+):
+    """Test invalid drive program slots in status responses raise clearly."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response="ret=OK,boil_level=0,drive_p1s=48",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    with pytest.raises(AirBaseHotWaterResponseError):
+        await device.get_status()
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_get_status_rejects_invalid_drive_program(aresponses, client_session):
+    """Test invalid drive program values in status responses raise clearly."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response="ret=OK,boil_level=0,drive_p=7",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    with pytest.raises(AirBaseHotWaterResponseError):
+        await device.get_status()
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
 async def test_set_control_sends_normalized_params(aresponses, client_session):
     """Test setting multiple writable controls."""
     aresponses.add(
         path_pattern=re.compile(
             r"/skyfi/hotwater/set_control_info\?"
             r"(?=.*boil_level=6)(?=.*boost=1)(?=.*vacation=0)"
+            r"(?=.*drive_p=5)(?=.*drive_p1s=42)(?=.*drive_p1e=14)"
         ),
         method_pattern="GET",
         match_querystring=True,
@@ -175,11 +281,21 @@ async def test_set_control_sends_normalized_params(aresponses, client_session):
 
     device = DaikinAirBaseHotWater("ip", session=client_session)
 
-    await device.set_control(boil_level=6, boost=True, vacation=0)
+    await device.set_control(
+        boil_level=6,
+        boost=True,
+        vacation=0,
+        drive_program="program_1",
+        program_1_start="21:00",
+        program_1_end="07:00",
+    )
 
     assert device.values.get("boil_level", invalidate=False) == "6"
     assert device.values.get("boost", invalidate=False) == "1"
     assert device.values.get("vacation", invalidate=False) == "0"
+    assert device.values.get("drive_p", invalidate=False) == "5"
+    assert device.values.get("drive_p1s", invalidate=False) == "42"
+    assert device.values.get("drive_p1e", invalidate=False) == "14"
     assert device.values.get("mode", invalidate=False) == "manual"
 
     aresponses.assert_all_requests_matched()
@@ -277,6 +393,98 @@ async def test_vacation_days_helper(aresponses, client_session):
     aresponses.assert_no_unused_routes()
 
 
+@pytest.mark.asyncio
+async def test_drive_program_helpers(aresponses, client_session):
+    """Test drive program helper methods normalize human and raw times."""
+    for expected_path in [
+        re.compile(
+            r"/skyfi/hotwater/set_control_info\?(?=.*drive_p1s=42)(?=.*drive_p1e=14)"
+        ),
+        re.compile(
+            r"/skyfi/hotwater/set_control_info\?(?=.*drive_p2s=22)(?=.*drive_p2e=28)"
+        ),
+    ]:
+        aresponses.add(
+            path_pattern=expected_path,
+            method_pattern="GET",
+            match_querystring=True,
+            response="ret=OK",
+        )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    await device.set_drive_program_1("21:00", "07:00")
+    await device.set_drive_program_2(22, 28)
+
+    assert device.values.get("drive_p1s", invalidate=False) == "42"
+    assert device.values.get("drive_p1e", invalidate=False) == "14"
+    assert device.values.get("drive_p2s", invalidate=False) == "22"
+    assert device.values.get("drive_p2e", invalidate=False) == "28"
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_drive_program_selection_helper(aresponses, client_session):
+    """Test active drive program helper accepts generic labels."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/set_control_info?drive_p=5",
+        method_pattern="GET",
+        match_querystring=True,
+        response="ret=OK",
+    )
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/set_control_info?drive_p=6",
+        method_pattern="GET",
+        match_querystring=True,
+        response="ret=OK",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+
+    await device.set_drive_program_selection("program_1")
+    await device.set_drive_program_selection("program_1_and_2")
+
+    assert device.values.get("drive_p", invalidate=False) == "6"
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_program_2_selection_requires_program_1_when_current_program_is_known(
+    client_session,
+):
+    """Test program 2 selection is blocked when program 1 is known inactive."""
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+    device.values["drive_p"] = "4"
+
+    with pytest.raises(ValueError):
+        await device.set_drive_program_selection("program_2")
+
+
+@pytest.mark.asyncio
+async def test_set_program_selection_is_mutually_exclusive(aresponses, client_session):
+    """Test selecting a fixed set program sends one drive_p value."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/set_control_info?drive_p=3",
+        method_pattern="GET",
+        match_querystring=True,
+        response="ret=OK",
+    )
+
+    device = DaikinAirBaseHotWater("ip", session=client_session)
+    device.values["drive_p"] = "2"
+
+    await device.set_drive_set_program(3)
+
+    assert device.values.get("drive_p", invalidate=False) == "3"
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
 def test_set_control_validation():
     """Test invalid control values are rejected before HTTP requests."""
     device = DaikinAirBaseHotWater("ip", session=MagicMock())
@@ -301,12 +509,58 @@ def test_set_control_validation():
     with pytest.raises(ValueError):
         DaikinAirBaseHotWater._normalize_control_params({"pow": 2})
 
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"drive_p": 0})
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"drive_program": "set_07"})
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"drive_p1s": 48})
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"drive_p1s": "21:15"})
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"drive_p1s": "24:00"})
+
+    with pytest.raises(ValueError):
+        DaikinAirBaseHotWater._normalize_control_params({"program_1_start": True})
+
     assert DaikinAirBaseHotWater._normalize_control_params(
-        {"power": "on", "boost": "off", "vacation_days": 14}
+        {
+            "power": "on",
+            "boost": "off",
+            "vacation_days": 14,
+            "drive_program": "set_04",
+            "program_1_start": "21:00",
+            "program_1_end": "7:00",
+            "program_2_start": "22",
+            "program_2_end": 28,
+        }
     ) == {
         "pow": "1",
         "boost": "0",
         "vacation_days": "14",
+        "drive_p": "4",
+        "drive_p1s": "42",
+        "drive_p1e": "14",
+        "drive_p2s": "22",
+        "drive_p2e": "28",
     }
+
+    assert DaikinAirBaseHotWater._normalize_control_params(
+        {"drive_program": "program_1_and_2"}
+    ) == {
+        "drive_p": "6",
+    }
+
+    assert DaikinAirBaseHotWater._normalize_control_params(
+        {"drive_program": "program_2"}
+    ) == {
+        "drive_p": "6",
+    }
+
+    assert DaikinAirBaseHotWater._drive_time_slot_to_time(42, "drive_p1s") == "21:00"
 
     assert device.humidity is None

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -7,6 +7,7 @@ import pytest
 import pytest_asyncio
 
 from pydaikin.daikin_airbase import DaikinAirBase
+from pydaikin.daikin_airbase_hotwater import DaikinAirBaseHotWater
 from pydaikin.daikin_brp069 import DaikinBRP069
 from pydaikin.daikin_brp072c import DaikinBRP072C
 from pydaikin.daikin_brp084 import DaikinBRP084
@@ -276,6 +277,63 @@ async def test_factory_detects_brp069(aresponses, client_session):
 
 
 @pytest.mark.asyncio
+async def test_factory_detects_airbase_hotwater(aresponses, client_session):
+    """Test that factory correctly detects AirBase hot water devices."""
+    # Mock 404 response for firmware 2.8.0 attempt
+    aresponses.add(
+        path_pattern="/dsiot/multireq",
+        method_pattern="POST",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+
+    # Mock 404 response for BRP069 attempt
+    aresponses.add(
+        path_pattern="/common/basic_info",
+        method_pattern="GET",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+
+    # Mock AirBase hot water response
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response=(
+            "ret=OK,pow=1,boost=0,vacation=0,vacation_days=0,"
+            "temp_set=63,temp_tank=56,temp_outside=13,boil_level=0"
+        ),
+    )
+
+    device = await DaikinFactory("192.168.1.100", session=client_session)
+
+    assert isinstance(device, DaikinAirBaseHotWater)
+    assert device.values.get("mode", invalidate=False) == "auto"
+    assert device.values.get("temp_tank", invalidate=False) == "56"
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_factory_explicit_airbase_hotwater(aresponses, client_session):
+    """Test that factory can be told to use AirBase hot water directly."""
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
+        method_pattern="GET",
+        response="ret=OK,pow=1,boost=0,vacation=0,vacation_days=0,boil_level=4",
+    )
+
+    device = await DaikinFactory(
+        "192.168.1.100", session=client_session, hot_water=True
+    )
+
+    assert isinstance(device, DaikinAirBaseHotWater)
+    assert device.values.get("mode", invalidate=False) == "manual"
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
 async def test_factory_detects_airbase(aresponses, client_session):
     """Test that factory correctly detects AirBase device (fallback from BRP069)."""
     # Mock 404 response for firmware 2.8.0 attempt
@@ -288,6 +346,13 @@ async def test_factory_detects_airbase(aresponses, client_session):
     # Mock 404 response for BRP069 attempt (to force fallback to AirBase)
     aresponses.add(
         path_pattern="/common/basic_info",
+        method_pattern="GET",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+
+    # Mock 404 response for AirBase hot water attempt
+    aresponses.add(
+        path_pattern="/skyfi/hotwater/get_unit_info",
         method_pattern="GET",
         response=aresponses.Response(status=404, text="Not Found"),
     )


### PR DESCRIPTION
## Description

Thanks for the opportunity to contribute! 😄 

Adds support for [Daikin RQWX60ZV1A](https://www.daikin.co.nz/pages/co2-hot-water-heat-pump) (C02 heat pump hot water system) that uses the Daikin Airbase BRP15B61 Controller.

This introduces a dedicated `DaikinAirBaseHotWater` device for the local `/skyfi/hotwater/...` API, with status parsing, typed status helpers, control setters, and local validation before writes. It is integrated with `DaikinFactory` through auto-detection or `hot_water=True`, and exposed in the CLI via `--hot-water`.

The hot water implementation is kept separate from the existing SkyFi/aircon protocol so current device behavior should be unaffected.

Tests added for parsing, validation, setters, and factory detection.

Test summary for scripts I ran on a local Daikin RQWX60ZV1A / BRP15B61 system:
```
[PASS] local validation
[PASS] raw hot-water HTTP API
[PASS] explicit hot-water factory
[PASS] factory auto-detection
[PASS] safe write-back check
[PASS] CLI state-change write exercise and restore
[PASS] CLI smoke tests
```

## Type of Change

<!-- Mark with an 'x' all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have tested this with real Daikin hardware (if applicable)

## Code Quality

<!-- Confirm you've followed the project standards -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Pre-commit hooks pass (run `pre-commit run --all-files`)

## String Formatting (New Code)

<!-- For new Python files or significant refactoring -->

- [X] If this PR adds new Python files, I've used double quotes (`"`) for strings following Python conventions
  
> **Note:** An automated check will highlight single quotes in new code. We're planning to migrate to standard string normalization in the future. New code should prefer double quotes (`"`) over single quotes (`'`) to ease this transition.

## Documentation

- [X] I have updated the documentation accordingly (if needed)
- [ ] I have updated the CHANGELOG (if applicable)

## Related Issues

<!-- Link related issues here using #issue_number -->

As described in https://github.com/fredrike/pydaikin/discussions/112

## Additional Notes

<!-- Any additional information that reviewers should know -->
