### PR TITLE
Add DSIOT feature controls, outdoor sensors and vane fix for BRP084

### DIFF
--- a/pydaikin/daikin_brp084.py
+++ b/pydaikin/daikin_brp084.py
@@ -68,7 +68,7 @@ class DaikinRequest:
         return payload
 
 
-# pylint: disable=abstract-method
+# pylint: disable=abstract-method,too-many-public-methods
 class DaikinBRP084(Appliance):
     """Daikin class for BRP devices with firmware 2.8.0."""
 
@@ -469,64 +469,9 @@ class DaikinBRP084(Appliance):
             # Get swing mode
             self.values['f_dir'] = self.get_swing_state(response)
 
-            # Get on/off feature toggles. Each is optional - not all firmware
-            # exposes every container (e.g. e_3003 or the outdoor e_3002).
-            for key in ('comfort', 'econo', 'outdoor_quiet', 'powerful'):
-                try:
-                    raw = self.find_value_by_pn(response, *self.get_path(key))
-                    self.values[key] = self.TRANSLATIONS[key].get(raw, 'off')
-                except DaikinException:
-                    pass
-
-            # Get current vertical vane position for the active mode.
-            try:
-                if self.values['mode'] in self.API_PATHS["swing_settings"]:
-                    vane_raw = self.find_value_by_pn(
-                        response,
-                        *self.get_path(
-                            "swing_settings", self.values['mode'], "vertical"
-                        ),
-                    )
-                    self.values['vane_vertical'] = self.VERTICAL_VANE_MAP.get(
-                        vane_raw, 'off'
-                    )
-            except DaikinException:
-                pass
-
-            # Get adapter capability flags / firmware info (optional).
-            for key, path_key in (
-                ('ver', 'firmware_ver'),
-                ('api_ver', 'api_ver'),
-            ):
-                try:
-                    self.values[key] = str(
-                        self.find_value_by_pn(response, *self.get_path(path_key))
-                    )
-                except DaikinException:
-                    pass
-
-            # Get outdoor unit sensors (optional, read-only).
-            try:
-                self.values['cmp_temp'] = str(
-                    self.hex_le_to_temp(
-                        self.find_value_by_pn(
-                            response, *self.get_path("compressor_temp")
-                        )
-                    )
-                )
-            except DaikinException:
-                pass
-
-            for key, path_key in (
-                ('model', 'indoor_model'),
-                ('outdoor_model', 'outdoor_model'),
-            ):
-                try:
-                    self.values[key] = self.hex_to_ascii(
-                        self.find_value_by_pn(response, *self.get_path(path_key))
-                    )
-                except DaikinException:
-                    pass
+            # Optional feature toggles, vane position, capability flags and
+            # outdoor sensors (each guarded - not all firmware exposes them).
+            self._extract_optional_readings(response)
 
             # Get energy data
             try:
@@ -546,6 +491,66 @@ class DaikinBRP084(Appliance):
         except DaikinException as e:
             _LOGGER.error("Error extracting values: %s", e)
             raise
+
+    def _extract_optional_readings(self, response):
+        """Extract optional values that not all firmware/models expose.
+
+        Covers the on/off feature toggles, the active-mode vertical vane
+        position, adapter capability/firmware info and outdoor-unit sensors.
+        Each read is guarded individually so a missing container just leaves
+        that value unset rather than failing the whole status update.
+        """
+        # On/off feature toggles (comfort/econo/outdoor_quiet/powerful).
+        for key in self.POWER_TOGGLES:
+            try:
+                raw = self.find_value_by_pn(response, *self.get_path(key))
+                self.values[key] = self.TRANSLATIONS[key].get(raw, 'off')
+            except DaikinException:
+                pass
+
+        # Current vertical vane position for the active mode.
+        try:
+            if self.values['mode'] in self.API_PATHS["swing_settings"]:
+                vane_raw = self.find_value_by_pn(
+                    response,
+                    *self.get_path("swing_settings", self.values['mode'], "vertical"),
+                )
+                self.values['vane_vertical'] = self.VERTICAL_VANE_MAP.get(
+                    vane_raw, 'off'
+                )
+        except DaikinException:
+            pass
+
+        # Adapter capability flags / firmware info.
+        for key, path_key in (('ver', 'firmware_ver'), ('api_ver', 'api_ver')):
+            try:
+                self.values[key] = str(
+                    self.find_value_by_pn(response, *self.get_path(path_key))
+                )
+            except DaikinException:
+                pass
+
+        # Outdoor-unit compressor temperature.
+        try:
+            self.values['cmp_temp'] = str(
+                self.hex_le_to_temp(
+                    self.find_value_by_pn(response, *self.get_path("compressor_temp"))
+                )
+            )
+        except DaikinException:
+            pass
+
+        # Decoded model strings.
+        for key, path_key in (
+            ('model', 'indoor_model'),
+            ('outdoor_model', 'outdoor_model'),
+        ):
+            try:
+                self.values[key] = self.hex_to_ascii(
+                    self.find_value_by_pn(response, *self.get_path(path_key))
+                )
+            except DaikinException:
+                pass
 
     async def _get_resource(self, path: str, params: Optional[Dict] = None):
         """Make the HTTP request to the device."""

--- a/pydaikin/daikin_brp084.py
+++ b/pydaikin/daikin_brp084.py
@@ -79,6 +79,13 @@ class DaikinBRP084(Appliance):
         "e_1002",
     ]
     E_1002_E_3001_PATH = E_1002_PATH + ["e_3001"]
+    E_1002_E_3003_PATH = E_1002_PATH + ["e_3003"]
+    E_1003_PATH = [
+        "/dsiot/edge/adr_0200.dgc_status",
+        "dgc_status",
+        "e_1003",
+    ]
+    ADP_I_PATH = ["/dsiot/edge.adp_i", "adp_i"]
 
     API_PATHS = {
         # Basic paths
@@ -93,7 +100,24 @@ class DaikinBRP084(Appliance):
             "e_A00D",
             "p_01",
         ],
-        "mac_address": ["/dsiot/edge.adp_i", "adp_i", "mac"],
+        "mac_address": ADP_I_PATH + ["mac"],
+        # Adapter info / capability flags
+        "firmware_ver": ADP_I_PATH + ["ver"],
+        "api_ver": ADP_I_PATH + ["api_ver"],
+        # Comfort airflow (e_3003/p_1D): 00=off, 01=on
+        "comfort": E_1002_E_3003_PATH + ["p_1D"],
+        # Econo (e_3003/p_24): 00=off, 01=on. Verified live read+write.
+        "econo": E_1002_E_3003_PATH + ["p_24"],
+        # Outdoor unit quiet (outdoor e_3002/p_3D): 00=off, 01=on.
+        "outdoor_quiet": E_1003_PATH + ["e_3002", "p_3D"],
+        # Powerful (outdoor e_3002/p_44): 00=off, 01=on. Verified live
+        # read+write; the unit also auto-cancels after ~20 min.
+        "powerful": E_1003_PATH + ["e_3002", "p_44"],
+        # Outdoor unit sensors (read-only)
+        "compressor_temp": E_1003_PATH + ["e_A005", "p_01"],
+        "discharge_temp": E_1003_PATH + ["e_A005", "p_02"],
+        "indoor_model": E_1002_PATH + ["e_A001", "p_01"],
+        "outdoor_model": E_1003_PATH + ["e_A001", "p_01"],
         # Mode-specific paths for temperature settings
         "temp_settings": {
             "cool": E_1002_E_3001_PATH + ["p_02"],
@@ -174,7 +198,34 @@ class DaikinBRP084(Appliance):
             '0': 'off',
             '1': 'on',
         },
+        'comfort': {
+            '00': 'off',
+            '01': 'on',
+        },
+        'econo': {
+            '00': 'off',
+            '01': 'on',
+        },
+        'outdoor_quiet': {
+            '00': 'off',
+            '01': 'on',
+        },
+        'powerful': {
+            '00': 'off',
+            '01': 'on',
+        },
     }
+
+    # Discrete vertical vane states. Only byte-0 has physical effect on this
+    # firmware (verified live): 'off'=neutral, 'swing'=oscillate, 'down'=floor.
+    # There is no continuous angle and no distinct "up" preset over wifi -
+    # byte-1 is accepted but inert, so 00800000 ("up") is NOT included.
+    VERTICAL_VANE_MAP = {
+        '00000000': 'off',
+        '17000000': 'down',
+        '0F000000': 'swing',
+    }
+    REVERSE_VERTICAL_VANE_MAP = {v: k for k, v in VERTICAL_VANE_MAP.items()}
 
     # Mapping between the values from firmware 2.8.0 to traditional API values
     MODE_MAP = {
@@ -203,6 +254,9 @@ class DaikinBRP084(Appliance):
 
     REVERSE_MODE_MAP = {v: k for k, v in MODE_MAP.items()}
     REVERSE_FAN_MODE_MAP = {v: k for k, v in FAN_MODE_MAP.items()}
+
+    # On/off feature toggles handled together (share mutual-exclusion rules).
+    POWER_TOGGLES = ('comfort', 'econo', 'outdoor_quiet', 'powerful')
 
     INFO_RESOURCES = []
 
@@ -246,6 +300,31 @@ class DaikinBRP084(Appliance):
     def hex_to_int(value: str) -> int:
         """Convert hexadecimal string to integer."""
         return int(value, 16)
+
+    @staticmethod
+    def hex_le_to_int(value: str, signed: bool = False) -> int:
+        """Convert a little-endian hex string (byte pairs) to an integer.
+
+        Multi-byte dgc_status values (e.g. outdoor temperature ``0D00`` or
+        compressor temperature ``8C0000``) are little-endian. Reading only the
+        first byte breaks for values that spill into the second byte or that are
+        negative (two's complement), e.g. a sub-zero outdoor temperature.
+        """
+        raw = bytes.fromhex(value)
+        return int.from_bytes(raw, byteorder='little', signed=signed)
+
+    @classmethod
+    def hex_le_to_temp(cls, value: str, divisor=2) -> float:
+        """Convert a little-endian signed hex temperature to degrees Celsius."""
+        return cls.hex_le_to_int(value, signed=True) / divisor
+
+    @staticmethod
+    def hex_to_ascii(value: str) -> str:
+        """Decode a hex-encoded ASCII string (model/serial), trimming padding."""
+        try:
+            return bytes.fromhex(value).decode('ascii').strip()
+        except (ValueError, UnicodeDecodeError):
+            return value
 
     @staticmethod
     def find_value_by_pn(data: dict, fr: str, *keys):
@@ -338,9 +417,10 @@ class DaikinBRP084(Appliance):
             self.values['pow'] = "0" if is_off else "1"
             self.values['mode'] = 'off' if is_off else self.MODE_MAP[mode_value]
 
-            # Get temperatures
+            # Get temperatures. Outdoor temp is a little-endian signed 2-byte
+            # value, so it must be decoded as such to handle sub-zero readings.
             self.values['otemp'] = str(
-                self.hex_to_temp(
+                self.hex_le_to_temp(
                     self.find_value_by_pn(response, *self.get_path("outdoor_temp"))
                 )
             )
@@ -389,6 +469,65 @@ class DaikinBRP084(Appliance):
             # Get swing mode
             self.values['f_dir'] = self.get_swing_state(response)
 
+            # Get on/off feature toggles. Each is optional - not all firmware
+            # exposes every container (e.g. e_3003 or the outdoor e_3002).
+            for key in ('comfort', 'econo', 'outdoor_quiet', 'powerful'):
+                try:
+                    raw = self.find_value_by_pn(response, *self.get_path(key))
+                    self.values[key] = self.TRANSLATIONS[key].get(raw, 'off')
+                except DaikinException:
+                    pass
+
+            # Get current vertical vane position for the active mode.
+            try:
+                if self.values['mode'] in self.API_PATHS["swing_settings"]:
+                    vane_raw = self.find_value_by_pn(
+                        response,
+                        *self.get_path(
+                            "swing_settings", self.values['mode'], "vertical"
+                        ),
+                    )
+                    self.values['vane_vertical'] = self.VERTICAL_VANE_MAP.get(
+                        vane_raw, 'off'
+                    )
+            except DaikinException:
+                pass
+
+            # Get adapter capability flags / firmware info (optional).
+            for key, path_key in (
+                ('ver', 'firmware_ver'),
+                ('api_ver', 'api_ver'),
+            ):
+                try:
+                    self.values[key] = str(
+                        self.find_value_by_pn(response, *self.get_path(path_key))
+                    )
+                except DaikinException:
+                    pass
+
+            # Get outdoor unit sensors (optional, read-only).
+            try:
+                self.values['cmp_temp'] = str(
+                    self.hex_le_to_temp(
+                        self.find_value_by_pn(
+                            response, *self.get_path("compressor_temp")
+                        )
+                    )
+                )
+            except DaikinException:
+                pass
+
+            for key, path_key in (
+                ('model', 'indoor_model'),
+                ('outdoor_model', 'outdoor_model'),
+            ):
+                try:
+                    self.values[key] = self.hex_to_ascii(
+                        self.find_value_by_pn(response, *self.get_path(path_key))
+                    )
+                except DaikinException:
+                    pass
+
             # Get energy data
             try:
                 self.values['today_runtime'] = self.find_value_by_pn(
@@ -400,6 +539,7 @@ class DaikinBRP084(Appliance):
                 )
                 if isinstance(energy_data, list) and len(energy_data) > 0:
                     self.values['datas'] = '/'.join(map(str, energy_data))
+
             except DaikinException:
                 pass
 
@@ -511,17 +651,21 @@ class DaikinBRP084(Appliance):
         ):
             return
 
-        # Set vertical swing
-        vertical_path = self.get_path("swing_settings", self.values['mode'], "vertical")
-        self.add_request(
-            requests,
-            vertical_path,
-            (
-                self.TURN_OFF_SWING_AXIS
-                if settings['f_dir'] in ('off', 'horizontal')
-                else self.TURN_ON_SWING_AXIS
-            ),
-        )
+        # Set vertical swing, unless an explicit vane position is also being
+        # set (that takes precedence for the vertical axis, handled separately).
+        if 'vane_vertical' not in settings:
+            vertical_path = self.get_path(
+                "swing_settings", self.values['mode'], "vertical"
+            )
+            self.add_request(
+                requests,
+                vertical_path,
+                (
+                    self.TURN_OFF_SWING_AXIS
+                    if settings['f_dir'] in ('off', 'horizontal')
+                    else self.TURN_ON_SWING_AXIS
+                ),
+            )
 
         # Set horizontal swing
         horizontal_path = self.get_path(
@@ -537,6 +681,60 @@ class DaikinBRP084(Appliance):
             ),
         )
 
+    def _handle_feature_toggles(self, settings, requests):
+        """Handle comfort/econo/outdoor_quiet/powerful on-off toggles.
+
+        Each accepts human ('on'/'off') or raw ('01'/'00') values. Enforces
+        the hardware mutual-exclusion documented in the unit's manual: Powerful
+        and {Comfort, Econo, Outdoor Quiet} cannot be active at the same time,
+        so enabling one side clears the other (mirroring the remote's
+        last-button-pressed-wins behaviour).
+        """
+        requested = {}
+        for key in self.POWER_TOGGLES:
+            if key not in settings:
+                continue
+            raw = self.human_to_daikin(key, settings[key])
+            if raw in ('00', '01'):
+                requested[key] = raw
+
+        if not requested:
+            return
+
+        trio = ('comfort', 'econo', 'outdoor_quiet')
+        # Turning Powerful on clears any currently-active trio member...
+        if requested.get('powerful') == '01':
+            for k in trio:
+                if self.values.get(k) == 'on' and k not in requested:
+                    requested[k] = '00'
+        # ...and turning on any trio member clears an active Powerful.
+        if any(requested.get(k) == '01' for k in trio):
+            if self.values.get('powerful') == 'on' and 'powerful' not in requested:
+                requested['powerful'] = '00'
+
+        for key, raw in requested.items():
+            self.add_request(requests, self.get_path(key), raw)
+
+    def _handle_vane_setting(self, settings, requests):
+        """Handle discrete vertical vane position settings.
+
+        Distinct from swing (f_dir): pins the vane to the floor ('down') or
+        restores 'off'/'swing'. Mode-specific, like swing. Only these byte-0
+        states have physical effect on this firmware.
+        """
+        if (
+            'vane_vertical' not in settings
+            or self.values['mode'] not in self.API_PATHS["swing_settings"]
+        ):
+            return
+
+        raw = self.REVERSE_VERTICAL_VANE_MAP.get(settings['vane_vertical'])
+        if raw is None:
+            return
+
+        path = self.get_path("swing_settings", self.values['mode'], "vertical")
+        self.add_request(requests, path, raw)
+
     async def set(self, settings):
         """Set settings on Daikin device."""
         await self._update_settings(settings)
@@ -546,7 +744,11 @@ class DaikinBRP084(Appliance):
         self._handle_power_setting(settings, requests)
         self._handle_temperature_setting(settings, requests)
         self._handle_fan_setting(settings, requests)
+        # vane_vertical takes precedence over swing for the vertical axis, so
+        # handle swing first and let an explicit vane position override it.
         self._handle_swing_setting(settings, requests)
+        self._handle_vane_setting(settings, requests)
+        self._handle_feature_toggles(settings, requests)
 
         if requests:
             request_payload = DaikinRequest(requests).serialize()
@@ -586,3 +788,96 @@ class DaikinBRP084(Appliance):
     def support_zone_count(self) -> bool:
         """Zones mode not supported in firmware 2.8.0"""
         return False
+
+    async def set_comfort_mode(self, mode):
+        """Enable or disable comfort airflow ('on'/'off')."""
+        await self.set({'comfort': mode})
+
+    @property
+    def support_comfort_mode(self) -> bool:
+        """Return True if the device exposes comfort airflow."""
+        return 'comfort' in self.values
+
+    @property
+    def comfort_mode(self) -> Optional[str]:
+        """Return current comfort airflow state ('on'/'off')."""
+        return self.values.get('comfort')
+
+    @property
+    def vertical_vane(self) -> Optional[str]:
+        """Return current vertical vane position ('off'/'down'/'swing')."""
+        return self.values.get('vane_vertical')
+
+    async def set_vertical_vane(self, position):
+        """Set the vertical vane position ('off'/'down'/'swing')."""
+        await self.set({'vane_vertical': position})
+
+    async def set_econo_mode(self, mode):
+        """Enable or disable Econo mode ('on'/'off')."""
+        await self.set({'econo': mode})
+
+    @property
+    def support_econo_mode(self) -> bool:
+        """Return True if the device exposes Econo mode."""
+        return 'econo' in self.values
+
+    @property
+    def econo_mode(self) -> Optional[str]:
+        """Return current Econo state ('on'/'off')."""
+        return self.values.get('econo')
+
+    async def set_outdoor_quiet_mode(self, mode):
+        """Enable or disable outdoor-unit quiet mode ('on'/'off')."""
+        await self.set({'outdoor_quiet': mode})
+
+    @property
+    def support_outdoor_quiet_mode(self) -> bool:
+        """Return True if the device exposes outdoor-unit quiet mode."""
+        return 'outdoor_quiet' in self.values
+
+    @property
+    def outdoor_quiet_mode(self) -> Optional[str]:
+        """Return current outdoor-unit quiet state ('on'/'off')."""
+        return self.values.get('outdoor_quiet')
+
+    async def set_powerful_mode(self, mode):
+        """Enable or disable Powerful mode ('on'/'off').
+
+        The unit also auto-cancels Powerful after ~20 minutes on its own.
+        """
+        await self.set({'powerful': mode})
+
+    @property
+    def support_powerful_mode(self) -> bool:
+        """Return True if the device exposes Powerful mode."""
+        return 'powerful' in self.values
+
+    @property
+    def powerful_mode(self) -> Optional[str]:
+        """Return current Powerful state ('on'/'off')."""
+        return self.values.get('powerful')
+
+    @property
+    def support_compressor_temperature(self) -> bool:
+        """Return True if the device reports outdoor compressor temperature."""
+        return 'cmp_temp' in self.values
+
+    @property
+    def compressor_temperature(self) -> Optional[float]:
+        """Return outdoor compressor temperature in Celsius (approximate)."""
+        return self._parse_number('cmp_temp')
+
+    @property
+    def model(self) -> Optional[str]:
+        """Return the decoded indoor unit model string."""
+        return self.values.get('model')
+
+    @property
+    def outdoor_model(self) -> Optional[str]:
+        """Return the decoded outdoor unit model string."""
+        return self.values.get('outdoor_model')
+
+    @property
+    def firmware_version(self) -> Optional[str]:
+        """Return the adapter firmware version."""
+        return self.values.get('ver')

--- a/tests/test_daikin_brp084.py
+++ b/tests/test_daikin_brp084.py
@@ -58,6 +58,23 @@ async def test_daikin_brp084(aresponses, client_session):
                                         {"pn": "p_02", "pv": "3c"},  # Humidity (60%)
                                     ],
                                 },
+                                {
+                                    "pn": "e_3003",
+                                    "pch": [
+                                        {"pn": "p_1D", "pv": "00"},  # Comfort OFF
+                                        {"pn": "p_24", "pv": "00"},  # Econo OFF
+                                    ],
+                                },
+                                {
+                                    "pn": "e_A001",
+                                    # Model "AMVA17MXTF" (hex ASCII, space-padded)
+                                    "pch": [
+                                        {
+                                            "pn": "p_01",
+                                            "pv": "2020202020414D564131374D585446",
+                                        },
+                                    ],
+                                },
                             ],
                         }
                     ],
@@ -75,9 +92,35 @@ async def test_daikin_brp084(aresponses, client_session):
                                 {
                                     "pn": "e_A00D",
                                     "pch": [
-                                        {"pn": "p_01", "pv": "22"}
-                                    ],  # Outside temp (17°C)
-                                }
+                                        {"pn": "p_01", "pv": "2200"}
+                                    ],  # Outside temp, LE 2-byte (17°C)
+                                },
+                                {
+                                    "pn": "e_A005",
+                                    "pch": [
+                                        {
+                                            "pn": "p_01",
+                                            "pv": "8C0000",
+                                        },  # Compressor 70°C
+                                        {"pn": "p_02", "pv": "410000"},
+                                    ],
+                                },
+                                {
+                                    "pn": "e_A001",
+                                    "pch": [
+                                        {
+                                            "pn": "p_01",
+                                            "pv": "2020202020414D564131374D5852",
+                                        },  # Model "AMVA17MXR"
+                                    ],
+                                },
+                                {
+                                    "pn": "e_3002",
+                                    "pch": [
+                                        {"pn": "p_3D", "pv": "00"},  # Quiet OFF
+                                        {"pn": "p_44", "pv": "00"},  # Powerful OFF
+                                    ],
+                                },
                             ],
                         }
                     ],
@@ -97,7 +140,18 @@ async def test_daikin_brp084(aresponses, client_session):
             },
             {
                 "fr": "/dsiot/edge.adp_i",
-                "pc": {"pn": "adp_i", "pch": [{"pn": "mac", "pv": "112233445566"}]},
+                "pc": {
+                    "pn": "adp_i",
+                    "pch": [
+                        {"pn": "mac", "pv": "112233445566"},
+                        {"pn": "ver", "pv": "3_12_3"},
+                        {"pn": "api_ver", "pv": "2_2"},
+                        {
+                            "pn": "func",
+                            "pch": [{"pn": "en_ipw_sep", "pv": 0}],
+                        },
+                    ],
+                },
                 "rsc": 2000,
             },
         ]
@@ -152,6 +206,25 @@ async def test_daikin_brp084(aresponses, client_session):
     assert device.values.get('f_dir') == 'off'
     assert device.values.get('mac') == '112233445566'
 
+    # New reads: comfort airflow, capabilities, outdoor sensors, models
+    assert device.values.get('comfort') == 'off'
+    assert device.support_comfort_mode is True
+    assert device.comfort_mode == 'off'
+    assert device.values.get('ver') == '3_12_3'
+    assert device.firmware_version == '3_12_3'
+    assert device.values.get('api_ver') == '2_2'
+    assert device.outside_temperature == 17.0  # LE 2-byte decode
+    assert device.compressor_temperature == 70.0
+    assert device.support_compressor_temperature is True
+    assert device.model == 'AMVA17MXTF'
+    assert device.outdoor_model == 'AMVA17MXR'
+
+    # New feature toggles: comfort/econo/outdoor_quiet/powerful
+    assert device.comfort_mode == 'off' and device.support_comfort_mode
+    assert device.econo_mode == 'off' and device.support_econo_mode
+    assert device.outdoor_quiet_mode == 'off' and device.support_outdoor_quiet_mode
+    assert device.powerful_mode == 'off' and device.support_powerful_mode
+
     # Test setting temperature
     await device.set({'stemp': '26.0'})
 
@@ -200,6 +273,23 @@ async def test_add_request_method(aresponses, client_session):
                                         {"pn": "p_02", "pv": "3c"},  # Humidity (60%)
                                     ],
                                 },
+                                {
+                                    "pn": "e_3003",
+                                    "pch": [
+                                        {"pn": "p_1D", "pv": "00"},  # Comfort OFF
+                                        {"pn": "p_24", "pv": "00"},  # Econo OFF
+                                    ],
+                                },
+                                {
+                                    "pn": "e_A001",
+                                    # Model "AMVA17MXTF" (hex ASCII, space-padded)
+                                    "pch": [
+                                        {
+                                            "pn": "p_01",
+                                            "pv": "2020202020414D564131374D585446",
+                                        },
+                                    ],
+                                },
                             ],
                         }
                     ],
@@ -217,9 +307,35 @@ async def test_add_request_method(aresponses, client_session):
                                 {
                                     "pn": "e_A00D",
                                     "pch": [
-                                        {"pn": "p_01", "pv": "22"}
-                                    ],  # Outside temp (17°C)
-                                }
+                                        {"pn": "p_01", "pv": "2200"}
+                                    ],  # Outside temp, LE 2-byte (17°C)
+                                },
+                                {
+                                    "pn": "e_A005",
+                                    "pch": [
+                                        {
+                                            "pn": "p_01",
+                                            "pv": "8C0000",
+                                        },  # Compressor 70°C
+                                        {"pn": "p_02", "pv": "410000"},
+                                    ],
+                                },
+                                {
+                                    "pn": "e_A001",
+                                    "pch": [
+                                        {
+                                            "pn": "p_01",
+                                            "pv": "2020202020414D564131374D5852",
+                                        },  # Model "AMVA17MXR"
+                                    ],
+                                },
+                                {
+                                    "pn": "e_3002",
+                                    "pch": [
+                                        {"pn": "p_3D", "pv": "00"},  # Quiet OFF
+                                        {"pn": "p_44", "pv": "00"},  # Powerful OFF
+                                    ],
+                                },
                             ],
                         }
                     ],
@@ -239,7 +355,18 @@ async def test_add_request_method(aresponses, client_session):
             },
             {
                 "fr": "/dsiot/edge.adp_i",
-                "pc": {"pn": "adp_i", "pch": [{"pn": "mac", "pv": "112233445566"}]},
+                "pc": {
+                    "pn": "adp_i",
+                    "pch": [
+                        {"pn": "mac", "pv": "112233445566"},
+                        {"pn": "ver", "pv": "3_12_3"},
+                        {"pn": "api_ver", "pv": "2_2"},
+                        {
+                            "pn": "func",
+                            "pch": [{"pn": "en_ipw_sep", "pv": 0}],
+                        },
+                    ],
+                },
                 "rsc": 2000,
             },
         ]
@@ -411,3 +538,145 @@ def test_support_humidity(values, expected):
     device = DaikinBRP084('127.0.0.1', session=mock_session)
     device.values.update(values)
     assert device.support_humidity is expected
+
+
+@pytest.mark.parametrize(
+    'value, expected',
+    [
+        ('0D00', 6.5),  # 0x000D = 13, /2
+        ('2200', 17.0),  # 0x0022 = 34, /2
+        ('F6FF', -5.0),  # 0xFFF6 = -10 (signed), /2
+        ('00FF', -128.0),  # 0xFF00 = -256 (signed), /2
+    ],
+)
+def test_hex_le_to_temp(value, expected):
+    """Little-endian signed temperature decoding (handles sub-zero)."""
+    assert DaikinBRP084.hex_le_to_temp(value) == expected
+
+
+@pytest.mark.parametrize(
+    'value, expected',
+    [
+        ('2020202020414D564131374D585446', 'AMVA17MXTF'),
+        ('202020202020202031313230303045', '112000E'),
+        ('notvalidhex', 'notvalidhex'),  # falls back to input
+    ],
+)
+def test_hex_to_ascii(value, expected):
+    """Hex-ASCII model/serial decoding with padding trimmed."""
+    assert DaikinBRP084.hex_to_ascii(value) == expected
+
+
+def test_handle_feature_toggles():
+    """Feature toggles accept human and raw values, rejecting garbage."""
+    mock_session = MagicMock()
+    device = DaikinBRP084('127.0.0.1', session=mock_session)
+
+    requests = []
+    device._handle_feature_toggles({'comfort': 'on'}, requests)
+    assert len(requests) == 1
+    assert requests[0].name == 'p_1D'
+    assert requests[0].value == '01'
+    assert requests[0].path == ['e_1002', 'e_3003']
+
+    # Econo (indoor e_3003/p_24)
+    requests = []
+    device._handle_feature_toggles({'econo': 'on'}, requests)
+    assert requests[0].name == 'p_24'
+    assert requests[0].value == '01'
+    assert requests[0].path == ['e_1002', 'e_3003']
+
+    # Outdoor quiet + powerful live on the outdoor unit (adr_0200 / e_3002)
+    requests = []
+    device._handle_feature_toggles({'outdoor_quiet': '01'}, requests)
+    assert requests[0].name == 'p_3D'
+    assert requests[0].path == ['e_1003', 'e_3002']
+    assert requests[0].to == '/dsiot/edge/adr_0200.dgc_status'
+
+    requests = []
+    device._handle_feature_toggles({'powerful': 'on'}, requests)
+    assert requests[0].name == 'p_44'
+    assert requests[0].path == ['e_1003', 'e_3002']
+    assert requests[0].to == '/dsiot/edge/adr_0200.dgc_status'
+
+    # Garbage / empty -> no-op
+    requests = []
+    device._handle_feature_toggles({'comfort': 'bogus'}, requests)
+    assert len(requests) == 0
+    device._handle_feature_toggles({}, requests)
+    assert len(requests) == 0
+
+
+def test_powerful_mutual_exclusion():
+    """Enabling Powerful clears active comfort/econo/quiet, and vice-versa."""
+    mock_session = MagicMock()
+    device = DaikinBRP084('127.0.0.1', session=mock_session)
+
+    # Powerful on while comfort+econo are active -> both get cleared to 00.
+    device.values.update({'comfort': 'on', 'econo': 'on', 'outdoor_quiet': 'off'})
+    requests = []
+    device._handle_feature_toggles({'powerful': 'on'}, requests)
+    by_name = {r.name: r.value for r in requests}
+    assert by_name['p_44'] == '01'  # powerful on
+    assert by_name['p_1D'] == '00'  # comfort cleared
+    assert by_name['p_24'] == '00'  # econo cleared
+    assert 'p_3D' not in by_name  # quiet was already off, not touched
+
+    # Turning comfort on while powerful is active -> powerful cleared.
+    device.values.update({'powerful': 'on', 'comfort': 'off'})
+    requests = []
+    device._handle_feature_toggles({'comfort': 'on'}, requests)
+    by_name = {r.name: r.value for r in requests}
+    assert by_name['p_1D'] == '01'  # comfort on
+    assert by_name['p_44'] == '00'  # powerful cleared
+
+
+def test_handle_vane_setting():
+    """Discrete vertical vane writes the mode-specific property."""
+    mock_session = MagicMock()
+    device = DaikinBRP084('127.0.0.1', session=mock_session)
+    device.values.update({'mode': 'cool'})
+
+    requests = []
+    device._handle_vane_setting({'vane_vertical': 'down'}, requests)
+    assert len(requests) == 1
+    assert requests[0].name == 'p_05'  # cool vertical
+    assert requests[0].value == '17000000'
+
+    requests = []
+    device._handle_vane_setting({'vane_vertical': 'swing'}, requests)
+    assert requests[0].value == '0F000000'
+
+    requests = []
+    device._handle_vane_setting({'vane_vertical': 'off'}, requests)
+    assert requests[0].value == '00000000'
+
+    # 'up' no longer exists (byte-1 is inert) and unknown positions -> no-op
+    for bad in ('up', 'sideways'):
+        requests = []
+        device._handle_vane_setting({'vane_vertical': bad}, requests)
+        assert len(requests) == 0
+
+    # In a mode without swing settings (off) -> no-op
+    device.values.update({'mode': 'off'})
+    requests = []
+    device._handle_vane_setting({'vane_vertical': 'down'}, requests)
+    assert len(requests) == 0
+
+
+def test_vane_overrides_swing_vertical():
+    """When both f_dir and vane_vertical are set, vane wins the vertical axis."""
+    mock_session = MagicMock()
+    device = DaikinBRP084('127.0.0.1', session=mock_session)
+    device.values.update({'mode': 'cool'})
+
+    requests = []
+    settings = {'f_dir': 'both', 'vane_vertical': 'down'}
+    device._handle_swing_setting(settings, requests)
+    device._handle_vane_setting(settings, requests)
+
+    verticals = [r for r in requests if r.name == 'p_05']
+    assert len(verticals) == 1  # no duplicate vertical write
+    assert verticals[0].value == '17000000'  # the vane value, not swing
+    # horizontal swing still applied
+    assert any(r.name == 'p_06' for r in requests)


### PR DESCRIPTION
## Summary

Adds Home Assistant-facing controls and sensors for BRP084 (firmware 2.8.0 / DSIOT) devices, reverse-engineered and **verified live** against a BRP069C4x adapter on a Daikin Alira (FTXM71W).

### New feature toggles (read + write)
| Feature | Property | Notes |
|---|---|---|
| Comfort airflow | `e_3003/p_1D` | on/off |
| Econo | `e_3003/p_24` | on/off |
| Outdoor Quiet | `adr_0200 e_3002/p_3D` | on/off |
| Powerful | `adr_0200 e_3002/p_44` | on/off; unit auto-cancels after ~20 min |

Each exposes `set_*_mode()`, a `*_mode` property, and a `support_*_mode` flag. The manual-documented **mutual exclusion** is enforced: enabling Powerful clears Comfort/Econo/Quiet and vice-versa (last-write-wins), mirroring the remote.

### Outdoor sensors & info (read-only)
- Compressor temperature, decoded indoor/outdoor model strings, adapter firmware/API version.

### Bug fix: outdoor temperature decoding
Outdoor temp is a little-endian **signed** 2-byte value. The previous code read only the first byte, which produced wrong results for sub-zero temperatures (e.g. -5°C read as +123°C). Now decoded correctly.

### Vertical vane
Exposes the three states that actually move the louver over wifi: `off` / `swing` / `down`. On this firmware byte-1 of the vane value is accepted but physically inert, so the previously-assumed `up` (`00800000`) preset is dropped as a no-op.

## Testing
- 28 unit tests (extended fixture + handler/mutual-exclusion/vane coverage); full suite green apart from pre-existing unrelated failures.
- Every read and write round-tripped live against a real device, including the Powerful mutual-exclusion clearing Comfort in real time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
