### PR TITLE
Fix fan_only to heat_cool transition sending stemp='--' (issue #31)

### DIFF
--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -262,7 +262,16 @@ class DaikinBRP069(Appliance):
                 key = val + self.values['mode']
                 if key in current_val:
                     self.values[k] = current_val[key]
-
+        if self.values.get('stemp') == '--':
+            for fallback_key in ('dt3', 'dt4', 'dt0', 'dt2'):
+                if current_val.get(fallback_key, '--') != '--':
+                    self.values['stemp'] = current_val[fallback_key]
+                    _LOGGER.debug(
+                        "stemp was '--', falling back to %s=%s",
+                        fallback_key,
+                        self.values['stemp'],
+                    )
+                    break
         return current_val
 
     async def set(self, settings):


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark with an 'x' all that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement

## Problem

When switching directly from `fan_only` (Daikin mode 6) to `heat_cool`/`auto` (mode 0), 
the device reports no stored temperature for fan mode (`dt6 = '--'`). 
If `dt0` is also `'--'` (unit hasn't been in auto mode recently), 
`_update_settings` sends `stemp: '--'` to the device, which rejects it with `PARAM NG`.

Reported in #31. The only workaround documented so far is routing through `cool` first.

## Fix

After the mode-specific temperature lookup loop, add a fallback: if `stemp` is still `'--'`, 
try stored temperatures from other modes (`dt3`→cool, `dt4`→heat, `dt0`→auto, `dt2`→dry) 
until a valid value is found.

This is safe for all devices and modes — it only activates when the lookup would have 
sent an invalid `'--'` value.

## Testing

Verified on BRP069-equipped Daikin multisplit (FTXF series) via Home Assistant automation 
that previously required a `fan_only → cool → heat_cool` workaround. Direct transition now works.

Fixes #31