### PR TITLE
Fix auth error on BRP069 when API key is provided

### DIFF
--- a/pydaikin/factory.py
+++ b/pydaikin/factory.py
@@ -54,6 +54,16 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
                 uuid=kwargs.get('uuid'),
                 ssl_context=kwargs.get('ssl_context'),
             )
+            try:
+                # Some BRP069 units also use keys to auth. 
+                # If treated as a BRP072 we won't be able to connect, 
+                # since this will force https on a unit that expects connection to port 80.
+                # We do a preliminary attempt at initialization to catch connection errors 
+                # and then fallback to the following cases.
+                await obj.init()
+            except Exception as e:
+                _LOGGER.debug(e)
+                obj = None
         # Try BRP084, firmware 2.8.0
         if not obj:
             try:


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark with an 'x' all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this with real Daikin hardware (if applicable)

## Code Quality

<!-- Confirm you've followed the project standards -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Pre-commit hooks pass (run `pre-commit run --all-files`)

## String Formatting (New Code)

<!-- For new Python files or significant refactoring -->

- [ ] If this PR adds new Python files, I've used double quotes (`"`) for strings following Python conventions
  
> **Note:** An automated check will highlight single quotes in new code. We're planning to migrate to standard string normalization in the future. New code should prefer double quotes (`"`) over single quotes (`'`) to ease this transition.

## Documentation

- [ ] I have updated the documentation accordingly (if needed)
- [ ] I have updated the CHANGELOG (if applicable)

## Related Issues

<!-- Link related issues here using #issue_number -->

Closes #

## Additional Notes

<!-- Any additional information that reviewers should know -->
