### PR TITLE
Fix auth error on BRP069B4x when API key is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ PyDaikin is a Python library for controlling Daikin air conditioners. It provide
 
 The following Daikin WiFi modules are currently supported:
 
-* **BRP069Axx/BRP069Bxx/BRP072Axx** - Standard WiFi adapters
+* **BRP069Axx/BRP069Bxx/BRP069B4x/BRP072Axx** - Standard WiFi adapters
 * **BRP15B61 (AirBase)** - Uses a similar protocol to BRP069Axx
 * **BRP072B/Cxx** - Requires HTTPS access and an authentication key
 * **BRP084** - Devices with firmware version 2.8.0 (uses a different API structure)

--- a/pydaikin/factory.py
+++ b/pydaikin/factory.py
@@ -31,7 +31,7 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
         await instance.__init__(*a, **kw)
         return instance._generated_object
 
-    async def __init__(
+    async def __init__(  # pylint: disable=too-many-branches
         self,
         device_id: str,
         session: Optional[ClientSession] = None,
@@ -44,11 +44,14 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
         # Check if this is a device with optional port from discovery
         device_ip, device_port = self._extract_ip_port(device_id)
         obj = None
+        already_initialized = False
 
         if password:
             obj = DaikinSkyFi(device_ip, session, password)
         elif key:
             obj = await self._try_brp072c(device_ip, session, key, kwargs)
+            if obj is not None:
+                already_initialized = True
         # Try BRP084, firmware 2.8.0
         if not obj:
             try:
@@ -88,7 +91,8 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
                 _LOGGER.debug("Using custom port %s for AirBase", device_port)
                 obj.base_url = f"http://{device_ip}:{device_port}"
 
-        await obj.init()
+        if not already_initialized:
+            await obj.init()
         if not obj.values.get("mode"):
             raise DaikinException(
                 f"Error creating device, {device_id} is not supported."

--- a/pydaikin/factory.py
+++ b/pydaikin/factory.py
@@ -54,6 +54,16 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
                 uuid=kwargs.get('uuid'),
                 ssl_context=kwargs.get('ssl_context'),
             )
+            try:
+                # Some BRP069 units also use keys to auth. 
+                # If treated as a BRP072 we won't be able to connect, 
+                # since this will force https on a unit that expects connection to port 80.
+                # We do a preliminary attempt at initialization to catch connection errors 
+                # and then fallback to the following cases.
+                await obj.init()
+            except Exception as e:
+                _LOGGER.debug(e)
+                obj = None
         # Try BRP084, firmware 2.8.0
         if not obj:
             try:

--- a/pydaikin/factory.py
+++ b/pydaikin/factory.py
@@ -4,6 +4,7 @@ import logging
 import re
 from typing import Optional, Tuple
 
+import aiohttp
 from aiohttp import ClientSession
 from aiohttp.web_exceptions import HTTPNotFound
 
@@ -47,23 +48,7 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
         if password:
             obj = DaikinSkyFi(device_ip, session, password)
         elif key:
-            obj = DaikinBRP072C(
-                device_ip,
-                session,
-                key=key,
-                uuid=kwargs.get('uuid'),
-                ssl_context=kwargs.get('ssl_context'),
-            )
-            try:
-                # Some BRP069 units also use keys to auth. 
-                # If treated as a BRP072 we won't be able to connect, 
-                # since this will force https on a unit that expects connection to port 80.
-                # We do a preliminary attempt at initialization to catch connection errors 
-                # and then fallback to the following cases.
-                await obj.init()
-            except Exception as e:
-                _LOGGER.debug(e)
-                obj = None
+            obj = await self._try_brp072c(device_ip, session, key, kwargs)
         # Try BRP084, firmware 2.8.0
         if not obj:
             try:
@@ -110,6 +95,34 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
             )
         _LOGGER.debug("Daikin generated object: %s", type(obj))
         self._generated_object = obj
+
+    @staticmethod
+    async def _try_brp072c(
+        device_ip: str,
+        session: Optional[ClientSession],
+        key: str,
+        kwargs: dict,
+    ) -> Optional[DaikinBRP072C]:
+        """Try to connect as BRP072C; return None if it fails."""
+        obj = DaikinBRP072C(
+            device_ip,
+            session,
+            key=key,
+            uuid=kwargs.get("uuid"),
+            ssl_context=kwargs.get("ssl_context"),
+        )
+        try:
+            # Some BRP069 units also use keys to auth.
+            # If treated as a BRP072 we won't be able to connect,
+            # since this will force https on a unit that expects
+            # connection to port 80. We do a preliminary attempt at
+            # initialization to catch connection errors and then
+            # fallback to the following cases.
+            await obj.init()
+            return obj
+        except (DaikinException, aiohttp.ClientError, TimeoutError, OSError) as err:
+            _LOGGER.debug(err)
+            return None
 
     @staticmethod
     def _extract_ip_port(device_id: str) -> Tuple[str, Optional[int]]:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -457,3 +457,69 @@ async def test_factory_brp069_custom_port_80(aresponses, client_session):
 
     aresponses.assert_all_requests_matched()
     aresponses.assert_no_unused_routes()
+
+
+# ---------------------------------------------------------------------------
+# Tests for _try_brp072c fallback behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_factory_brp072c_success(aresponses, client_session):
+    """Key provided and BRP072C init succeeds -> returns BRP072C."""
+    aresponses.add(
+        path_pattern="/common/register_terminal",
+        method_pattern="GET",
+        response="ret=OK",
+    )
+    aresponses.add(
+        path_pattern="/common/register_terminal",
+        method_pattern="GET",
+        response="ret=OK",
+    )
+    aresponses.add(
+        path_pattern="/common/get_datetime",
+        method_pattern="GET",
+        response="ret=OK,sta=2,cur=2023/8/27 21:54:1,reg=eu,dst=1,zone=313",
+    )
+    aresponses.add(
+        path_pattern="/common/basic_info",
+        method_pattern="GET",
+        response="ret=OK,type=aircon,reg=eu,dst=1,ver=1_2_54,rev=203DE8C,pow=1,err=0,location=0,name=%4e%6f%74%74%65,icon=3,method=home only,port=30050,id=,pw=,lpw_flag=0,adp_kind=3,pv=3.20,cpv=3,cpv_minor=20,led=1,en_setzone=1,mac=409F38D107AC,adp_mode=run,en_hol=0,ssid1=Pinguino Curioso,radio1=-35,grp_name=,en_grp=0",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_sensor_info",
+        method_pattern="GET",
+        response="ret=OK,htemp=25.0,hhum=-,otemp=21.0,err=0,cmpfreq=40",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_model_info",
+        method_pattern="GET",
+        response="ret=OK,model=0000,type=N,pv=3.20,cpv=3,cpv_minor=20,mid=NA,humd=0,s_humd=0,acled=0,land=0,elec=1,temp=1,temp_rng=0,m_dtct=1,ac_dst=--,disp_dry=0,dmnd=1,en_scdltmr=1,en_frate=1,en_fdir=1,s_fdir=3,en_rtemp_a=0,en_spmode=7,en_ipw_sep=1,en_mompow=0,hmlmt_l=10.0",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_control_info",
+        method_pattern="GET",
+        response="ret=OK,pow=1,mode=2,adv=,stemp=M,shum=50,dt1=25.0,dt2=M,dt3=25.0,dt4=25.0,dt5=25.0,dt7=25.0,dh1=AUTO,dh2=50,dh3=0,dh4=0,dh5=0,dh7=AUTO,dhh=50,b_mode=2,b_stemp=M,b_shum=50,alert=255,f_rate=A,f_dir=0,b_f_rate=5,b_f_dir=0,dfr1=5,dfr2=5,dfr3=A,dfr4=5,dfr5=5,dfr6=3,dfr7=5,dfrh=5,dfd1=0,dfd2=0,dfd3=2,dfd4=0,dfd5=0,dfd6=2,dfd7=0,dfdh=0,dmnd_run=0,en_demand=0",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_day_power_ex",
+        method_pattern="GET",
+        response="ret=OK,curr_day_heat=0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0,prev_1day_heat=0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0,curr_day_cool=0/0/0/0/0/0/0/0/0/0/1/0/0/0/0/0/0/0/0/0/0/0/0/0,prev_1day_cool=0/1/0/1/0/1/0/1/0/2/3/2/3/1/0/0/0/0/5/1/0/1/1/0",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_week_power",
+        method_pattern="GET",
+        response="ret=OK,today_runtime=38,datas=5700/4000/6100/3900/2200/3400/400",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_year_power",
+        method_pattern="GET",
+        response="ret=OK,previous_year=7/0/1/0/1/21/57/24/2/0/0/2,this_year=4/0/0/0/1/18/40/53",
+    )
+
+    device = await DaikinFactory("192.168.1.100", session=client_session, key="testkey")
+
+    assert isinstance(device, DaikinBRP072C)
+    assert device.values.get("mode", invalidate=False) == "2"
+    assert device.values.get("mac", invalidate=False) == "409F38D107AC"


### PR DESCRIPTION
## Description

Some BRP069 units also use keys to auth.
If treated as a BRP072 we won't be able to connect, since this will force https on a unit that expects
connection to port 80. We do a preliminary attempt at initialization to catch connection errors and then
fallback to the following cases.

## Type of Change

<!-- Mark with an 'x' all that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this with real Daikin hardware (if applicable)

## Code Quality

<!-- Confirm you've followed the project standards -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)

## String Formatting (New Code)

<!-- For new Python files or significant refactoring -->

- [x] If this PR adds new Python files, I've used double quotes (`"`) for strings following Python conventions
  
> **Note:** An automated check will highlight single quotes in new code. We're planning to migrate to standard string normalization in the future. New code should prefer double quotes (`"`) over single quotes (`'`) to ease this transition.

## Documentation

- [ ] I have updated the documentation accordingly (if needed)
- [ ] I have updated the CHANGELOG (if applicable)

## Related Issues

<!-- Link related issues here using #issue_number -->

Closes #

## Additional Notes

<!-- Any additional information that reviewers should know -->
