### PR TITLE
Update exception handling in hex_to_ascii method

### DIFF
--- a/pydaikin/daikin_brp084.py
+++ b/pydaikin/daikin_brp084.py
@@ -314,7 +314,7 @@ class DaikinBRP084(Appliance):
         """Decode a hex-encoded ASCII string (model/serial), trimming padding."""
         try:
             return bytes.fromhex(value).decode('ascii').strip()
-        except (ValueError, UnicodeDecodeError):
+        except (TypeError, ValueError, UnicodeDecodeError):
             return value
 
     @staticmethod


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Attempt to fix https://github.com/home-assistant/core/issues/177877

## Type of Change

<!-- Mark with an 'x' all that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this with real Daikin hardware (if applicable)

## Code Quality

<!-- Confirm you've followed the project standards -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Pre-commit hooks pass (run `pre-commit run --all-files`)

## String Formatting (New Code)

<!-- For new Python files or significant refactoring -->

- [ ] If this PR adds new Python files, I've used double quotes (`"`) for strings following Python conventions
  
> **Note:** An automated check will highlight single quotes in new code. We're planning to migrate to standard string normalization in the future. New code should prefer double quotes (`"`) over single quotes (`'`) to ease this transition.

## Documentation

- [ ] I have updated the documentation accordingly (if needed)
- [ ] I have updated the CHANGELOG (if applicable)

## Related Issues

<!-- Link related issues here using #issue_number -->

Closes #

## Additional Notes

<!-- Any additional information that reviewers should know -->
