### PR TITLE
feat: replace unmaintained netifaces dependency with psutil

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -23,4 +23,4 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint --extension-pkg-whitelist=netifaces bin/pydaikin pydaikin/*.py
+        pylint bin/pydaikin pydaikin/*.py

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 .idea/
 *.pyc
 venv/
+.venv/
 .coverage
 .vscode
 .python-version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,7 @@ repos:
       - id: pylint
         additional_dependencies:
         - aiohttp==3.7.3
-        - netifaces==0.11.0
+        - psutil
         - urllib3==1.26.3
         - tenacity==8.2.3
         exclude: 'tests/'
-        args:
-        - --ignore=setup.py
-        - --extension-pkg-allow-list=netifaces

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: pylint
         additional_dependencies:
         - aiohttp==3.7.3
-        - psutil
+        - psutil==7.2.2
         - urllib3==1.26.3
         - tenacity==8.2.3
         exclude: 'tests/'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 pydaikin is a Python (>=3.12) library for interfacing with Daikin HVAC appliances.
 
 ## Dependencies
-- Core: `netifaces`, `aiohttp`, `urllib3`, `tenacity`
+- Core: `psutil`, `aiohttp`, `urllib3`, `tenacity`
 - Avoid adding new dependencies without discussion.
 
 ## Setup
@@ -25,7 +25,7 @@ pre-commit run --all-files
 Individual hooks:
 - **ruff check** — linting with auto-fix (`--fix`), replaces flake8/isort/pylint for most rules
 - **ruff format** — formatter (line length 88, target py312+), replaces black
-- **pylint** — static analysis (excludes `tests/`, extends `netifaces`)
+- **pylint** — static analysis (excludes `tests/`)
 
 Configuration for ruff lives in `pyproject.toml` under `[tool.ruff]`.
 

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -18,7 +18,7 @@ definitions:
           - pip install -r requirements-test.txt
           - ruff format --check .
           - ruff check .
-          - pylint --extension-pkg-whitelist=netifaces bin/pydaikin pydaikin/*.py
+          - pylint bin/pydaikin pydaikin/*.py
 
 pipelines:
   default:

--- a/pydaikin/discovery.py
+++ b/pydaikin/discovery.py
@@ -3,7 +3,7 @@
 import logging
 import socket
 
-import netifaces
+import psutil
 
 from .response import parse_response
 
@@ -36,18 +36,13 @@ class Discovery:  # pylint: disable=too-few-public-methods
         if ip:
             broadcast_ips = [ip]
         else:
-            # get all IPv4 definitions in the system
-            net_groups = [
-                netifaces.ifaddresses(i)[netifaces.AF_INET]
-                for i in netifaces.interfaces()
-                if netifaces.AF_INET in netifaces.ifaddresses(i)
+            # get all IPv4 broadcast addresses in the system
+            broadcast_ips = [
+                addr.broadcast
+                for addrs in psutil.net_if_addrs().values()
+                for addr in addrs
+                if addr.family == socket.AF_INET and addr.broadcast
             ]
-
-            # flatten the previous list
-            net_ips = [item for sublist in net_groups for item in sublist]
-
-            # from those, get the broadcast IPs, if available
-            broadcast_ips = [i['broadcast'] for i in net_ips if 'broadcast' in i.keys()]
 
         # send a daikin broadcast to each one of the ips
         for ip_address in broadcast_ips:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Application Frameworks",
   "Topic :: Home Automation",
 ]
-dependencies = ['netifaces', 'aiohttp', 'urllib3', 'tenacity']
+dependencies = ['psutil', 'aiohttp', 'urllib3', 'tenacity']
 requires-python = ">= 3.12"
 readme = "README.md"
 maintainers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-netifaces
+psutil
 aiohttp
 urllib3
 tenacity

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,119 @@
+"""Tests for the Discovery module."""
+
+import socket
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from pydaikin.discovery import DISCOVERY_MSG, UDP_DST_PORT, Discovery
+
+
+def _addr(family, address, broadcast):
+    """Build a mock psutil net_if_addrs address entry."""
+    return SimpleNamespace(
+        family=family,
+        address=address,
+        netmask="255.255.255.0",
+        broadcast=broadcast,
+    )
+
+
+def _fake_socket():
+    sock = Mock()
+    sock.sendto.return_value = None
+    sock.recvfrom.side_effect = socket.timeout()
+    return sock
+
+
+def test_poll_broadcasts_to_all_interface_broadcasts():
+    """Broadcast is sent to every IPv4 interface broadcast address."""
+    addrs = {
+        "en0": [
+            _addr(socket.AF_INET, "192.168.1.5", "192.168.1.255"),
+            _addr(socket.AF_INET6, "fe80::1", None),
+        ],
+        "en1": [_addr(socket.AF_INET, "10.0.0.5", "10.0.0.255")],
+        "lo0": [_addr(socket.AF_INET, "127.0.0.1", None)],
+    }
+    sock = _fake_socket()
+    with (
+        patch("psutil.net_if_addrs", return_value=addrs),
+        patch("socket.socket", return_value=sock),
+    ):
+        discovery = Discovery()
+        result = discovery.poll()
+
+    targets = {call.args[1][0] for call in sock.sendto.call_args_list}
+    assert targets == {"192.168.1.255", "10.0.0.255"}
+    msg = bytes(DISCOVERY_MSG, "UTF-8")
+    for call in sock.sendto.call_args_list:
+        assert call.args[0] == msg
+        assert call.args[1][1] == UDP_DST_PORT
+    assert list(result) == []
+
+
+def test_poll_with_ip_only_sends_to_given_ip():
+    """When an ip is given, only that address is used as broadcast target."""
+    sock = _fake_socket()
+    with patch("socket.socket", return_value=sock):
+        discovery = Discovery()
+        discovery.poll(ip="192.168.1.255")
+
+    sock.sendto.assert_called_once_with(
+        bytes(DISCOVERY_MSG, "UTF-8"), ("192.168.1.255", UDP_DST_PORT)
+    )
+
+
+def test_poll_returns_discovered_devices():
+    """Devices answering the broadcast are parsed and returned."""
+    response = b"ret=OK,type=aircon,mac=409F38D107AC,name=Test,port=30050"
+    sock = _fake_socket()
+    sock.recvfrom.side_effect = [(response, ("192.168.1.10", 30050)), socket.timeout()]
+    addrs = {"en0": [_addr(socket.AF_INET, "192.168.1.5", "192.168.1.255")]}
+    with (
+        patch("psutil.net_if_addrs", return_value=addrs),
+        patch("socket.socket", return_value=sock),
+    ):
+        discovery = Discovery()
+        devices = list(discovery.poll())
+
+    assert len(devices) == 1
+    device = devices[0]
+    assert device["mac"] == "409F38D107AC"
+    assert device["ip"] == "192.168.1.10"
+    assert device["port"] == 30050
+
+
+def test_poll_stops_when_device_name_matches():
+    """Polling stops early when a device matching stop_if_found responds."""
+    response = b"ret=OK,type=aircon,mac=409F38D107AC,name=Living Room,port=30050"
+    sock = _fake_socket()
+    sock.recvfrom.side_effect = [(response, ("192.168.1.10", 30050))]
+    addrs = {"en0": [_addr(socket.AF_INET, "192.168.1.5", "192.168.1.255")]}
+    with (
+        patch("psutil.net_if_addrs", return_value=addrs),
+        patch("socket.socket", return_value=sock),
+    ):
+        discovery = Discovery()
+        devices = list(discovery.poll(stop_if_found="living room"))
+
+    assert len(devices) == 1
+    assert devices[0]["name"] == "Living Room"
+    sock.recvfrom.assert_called_once()
+
+
+@pytest.mark.parametrize("response", [b"garbage", b"ret=ERR,err=0"])
+def test_poll_ignores_invalid_responses(response):
+    """Invalid or error responses are ignored without raising."""
+    sock = _fake_socket()
+    sock.recvfrom.side_effect = [(response, ("192.168.1.99", 30050)), socket.timeout()]
+    addrs = {"en0": [_addr(socket.AF_INET, "192.168.1.5", "192.168.1.255")]}
+    with (
+        patch("psutil.net_if_addrs", return_value=addrs),
+        patch("socket.socket", return_value=sock),
+    ):
+        discovery = Discovery()
+        devices = list(discovery.poll())
+
+    assert devices == []


### PR DESCRIPTION
Closes #117

`netifaces` is archived and unmaintained, with open bugs against Python 3.14 and no plan to fix them. This PR replaces its only use with `psutil`, which is actively maintained and cross-platform.

## Changes
- **pydaikin/discovery.py**: enumerate IPv4 interface broadcast addresses via `psutil.net_if_addrs()` instead of `netifaces` (same resulting addresses, cross-platform).
- **pyproject.toml / requirements.txt**: swap `netifaces` for `psutil`.
- **.pre-commit-config.yaml / .github/workflows/pylint.yml / bitbucket-pipelines.yml**: drop the `netifaces` pylint extension allow-list entries.
- **tests/test_discovery.py**: add unit tests for broadcast selection, `ip=` override, device parsing, stop-on-name, and invalid-response handling.

## Verification
- `pre-commit run --all-files` passes (ruff + pylint).
- Full test suite: 215 passed, 10 skipped.