### PR TITLE
Fix BRP084 dsiot energy consumption reporting

### DIFF
--- a/pydaikin/daikin_brp084.py
+++ b/pydaikin/daikin_brp084.py
@@ -505,6 +505,8 @@ class DaikinBRP084(Appliance):
             _LOGGER.error("Error extracting values: %s", e)
             raise
 
+        self._register_energy_consumption_history()
+
     def _extract_optional_readings(self, response):
         """Extract optional values that not all firmware/models expose.
 
@@ -892,6 +894,15 @@ class DaikinBRP084(Appliance):
     def support_powerful_mode(self) -> bool:
         """Return True if the device exposes Powerful mode."""
         return 'powerful' in self.values
+
+    @property
+    def today_energy_consumption(self):
+        """Return today's energy consumption in kWh."""
+        cool = self.today_cool_energy_consumption
+        heat = self.today_heat_energy_consumption
+        if cool is None and heat is None:
+            return self.today_total_energy_consumption or 0
+        return (cool or 0) + (heat or 0)
 
     @property
     def powerful_mode(self) -> Optional[str]:

--- a/tests/test_daikin_brp084.py
+++ b/tests/test_daikin_brp084.py
@@ -218,6 +218,10 @@ async def test_daikin_brp084(aresponses, client_session):
     assert device.support_compressor_temperature is True
     assert device.model == 'AMVA17MXTF'
     assert device.outdoor_model == 'AMVA17MXR'
+    assert device.values.get('datas') == '100/200/300/400/500/600/700'
+    assert device.today_total_energy_consumption == 0.7
+    assert device.today_energy_consumption == 0.7
+    assert device._energy_consumption_history['total'][0].today == 0.7
 
     # New feature toggles: comfort/econo/outdoor_quiet/powerful
     assert device.comfort_mode == 'off' and device.support_comfort_mode
@@ -538,6 +542,18 @@ def test_support_humidity(values, expected):
     device = DaikinBRP084('127.0.0.1', session=mock_session)
     device.values.update(values)
     assert device.support_humidity is expected
+
+
+def test_aggregate_energy_used_when_split_energy_is_unavailable():
+    """BRP084 exposes aggregate daily energy without cool/heat split counters."""
+    mock_session = MagicMock()
+    device = DaikinBRP084('127.0.0.1', session=mock_session)
+    device.values.update({'datas': '7300/8400/9900/7000/3000/900/900'})
+
+    assert device.today_cool_energy_consumption is None
+    assert device.today_heat_energy_consumption is None
+    assert device.today_total_energy_consumption == 0.9
+    assert device.today_energy_consumption == 0.9
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Register BRP084 dsiot energy consumption history after status parsing.
- Fall back to aggregate `today_total_energy_consumption` for `today_energy_consumption` when split cool/heat counters are unavailable.
- This addresses a downstream Home Assistant symptom where BRP084 devices can show zero daily energy despite aggregate dsiot `week_power.datas` data being present.

## Details

BRP084 dsiot devices already parse aggregate weekly power data from `week_power.datas`; `today_total_energy_consumption` uses the last aggregate value as kWh. Some devices/firmware do not expose split `curr_day_cool` / `curr_day_heat` counters, so the inherited `today_energy_consumption` implementation returns `0` by summing two unavailable split values.

This keeps the inherited split-counter behavior when either cool or heat data exists, and only falls back to aggregate total energy when both split counters are unavailable.

The BRP084 status path also overrides the base update path, so this PR registers energy consumption history after BRP084 status parsing. That gives the estimated power path history to work from after aggregate energy changes.

Related: #119 is a broader BRP084 energy PR that adds yearly energy and optional cool/heat breakdown support. This PR is intentionally narrower and preserves aggregate-only behavior for devices that expose `datas` but not split counters.

## Testing

- Existing BRP084 fixture with `datas=[100,200,300,400,500,600,700]` now asserts:
  - `today_total_energy_consumption == 0.7`
  - `today_energy_consumption == 0.7`
  - history total for today is `0.7`
- Added sanitized real-shape regression with `datas=[7300,8400,9900,7000,3000,900,900]`, expecting `0.9`.
- `uv run pytest tests/test_daikin_brp084.py -q` -> `49 passed`
- `uv run pytest tests/test_energy_consumption.py tests/test_power_sensor.py -q` -> `11 passed, 3 skipped`
- `uvx ruff check pydaikin/daikin_brp084.py tests/test_daikin_brp084.py` -> passed
- Full `uv run pytest -q` -> `210 passed, 10 skipped`
