### PR TITLE
fix: close aiohttp sessions created by the factory and CLI

### DIFF
--- a/bin/pydaikin
+++ b/bin/pydaikin
@@ -17,6 +17,7 @@ from pydaikin.factory import DaikinFactory
 async def list_all_devices():
     """Print all discovered devices."""
     for dev in discovery.get_devices():
+        appl = None
         try:
             appl = await DaikinFactory(dev['ip'])
             support_energy_consumption = (
@@ -24,6 +25,9 @@ async def list_all_devices():
             )
         except ClientError:
             support_energy_consumption = "Unknown"
+        finally:
+            if appl:
+                await appl.aclose()
         print(
             f"{dev['ip'][:18]}"
             f" ({dev['mac']}): {dev['name']}"
@@ -138,26 +142,31 @@ async def main():  # pylint: disable=too-many-branches
     else:
         daikin = await DaikinFactory(args.device, key=args.key, password=args.password)
 
-        if not _settings:
-            daikin.show_values(not args.all)
-        else:
-            await daikin.set(_settings)
+        try:
+            if not _settings:
+                daikin.show_values(not args.all)
+            else:
+                await daikin.set(_settings)
 
-        if args.sensor:
-            print('\nPress CTRL+C to stop logging sensor data...\n')
+            if args.sensor:
+                print('\nPress CTRL+C to stop logging sensor data...\n')
 
-            with (
-                open(args.file, 'a', encoding='utf-8') if args.file else nullcontext()
-            ) as file:
-                try:
-                    while True:
-                        await daikin.update_status()
-                        daikin.show_sensors()
-                        if args.file:
-                            daikin.log_sensors(file)
-                        await sleep(30)
-                except KeyboardInterrupt:
-                    pass
+                with (
+                    open(args.file, 'a', encoding='utf-8')
+                    if args.file
+                    else nullcontext()
+                ) as file:
+                    try:
+                        while True:
+                            await daikin.update_status()
+                            daikin.show_sensors()
+                            if args.file:
+                                daikin.log_sensors(file)
+                            await sleep(30)
+                    except KeyboardInterrupt:
+                        pass
+        finally:
+            await daikin.aclose()
 
 
 run(main())

--- a/pydaikin/factory.py
+++ b/pydaikin/factory.py
@@ -31,7 +31,7 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
         await instance.__init__(*a, **kw)
         return instance._generated_object
 
-    async def __init__(  # pylint: disable=too-many-branches
+    async def __init__(  # pylint: disable=too-many-branches,too-many-statements,broad-exception-caught
         self,
         device_id: str,
         session: Optional[ClientSession] = None,
@@ -45,6 +45,14 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
         device_ip, device_port = self._extract_ip_port(device_id)
         obj = None
         already_initialized = False
+
+        # Create a single session for all detection trials if the caller did not
+        # provide one, so that failed trials do not leak their own sessions.
+        if session is None:
+            session = ClientSession()
+            own_session = True
+        else:
+            own_session = False
 
         if password:
             obj = DaikinSkyFi(device_ip, session, password)
@@ -91,12 +99,19 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
                 _LOGGER.debug("Using custom port %s for AirBase", device_port)
                 obj.base_url = f"http://{device_ip}:{device_port}"
 
-        if not already_initialized:
-            await obj.init()
-        if not obj.values.get("mode"):
-            raise DaikinException(
-                f"Error creating device, {device_id} is not supported."
-            )
+        if own_session:
+            setattr(obj, "_own_session", True)
+        try:
+            if not already_initialized:
+                await obj.init()
+            if not obj.values.get("mode"):
+                raise DaikinException(
+                    f"Error creating device, {device_id} is not supported."
+                )
+        except Exception:
+            if own_session:
+                await obj.aclose()
+            raise
         _LOGGER.debug("Daikin generated object: %s", type(obj))
         self._generated_object = obj
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -523,3 +523,143 @@ async def test_factory_brp072c_success(aresponses, client_session):
     assert isinstance(device, DaikinBRP072C)
     assert device.values.get("mode", invalidate=False) == "2"
     assert device.values.get("mac", invalidate=False) == "409F38D107AC"
+
+
+# ---------------------------------------------------------------------------
+# Tests for ClientSession lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_factory_owns_and_closes_created_session(aresponses):
+    """A session created by the factory is owned and closed by aclose()."""
+    # Mock 404 for firmware 2.8.0 attempt (to force fallback)
+    aresponses.add(
+        path_pattern="/dsiot/multireq",
+        method_pattern="POST",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+
+    # Mock BRP069 responses (detection phase)
+    aresponses.add(
+        path_pattern="/common/basic_info",
+        method_pattern="GET",
+        response="ret=OK,type=aircon,reg=eu,dst=1,ver=1_2_54,rev=203DE8C,pow=1,err=0,location=0,name=%4e%6f%74%74%65,icon=3,method=home only,port=30050,id=,pw=,lpw_flag=0,adp_kind=3,pv=3.20,cpv=3,cpv_minor=20,led=1,en_setzone=1,mac=409F38D107AC,adp_mode=run,en_hol=0,ssid1=Pinguino Curioso,radio1=-35,grp_name=,en_grp=0",
+    )
+    # Mock BRP069 init responses (basic_info is skipped due to caching from detection)
+    aresponses.add(
+        path_pattern="/common/get_datetime",
+        method_pattern="GET",
+        response="ret=OK,sta=2,cur=2023/8/27 21:54:1,reg=eu,dst=1,zone=313",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_sensor_info",
+        method_pattern="GET",
+        response="ret=OK,htemp=25.0,hhum=-,otemp=21.0,err=0,cmpfreq=40",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_model_info",
+        method_pattern="GET",
+        response="ret=OK,model=0000,type=N,pv=3.20,cpv=3,cpv_minor=20,mid=NA,humd=0,s_humd=0,acled=0,land=0,elec=1,temp=1,temp_rng=0,m_dtct=1,ac_dst=--,disp_dry=0,dmnd=1,en_scdltmr=1,en_frate=1,en_fdir=1,s_fdir=3,en_rtemp_a=0,en_spmode=7,en_ipw_sep=1,en_mompow=0,hmlmt_l=10.0",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_control_info",
+        method_pattern="GET",
+        response="ret=OK,pow=1,mode=2,adv=,stemp=M,shum=50,dt1=25.0,dt2=M,dt3=25.0,dt4=25.0,dt5=25.0,dt7=25.0,dh1=AUTO,dh2=50,dh3=0,dh4=0,dh5=0,dh7=AUTO,dhh=50,b_mode=2,b_stemp=M,b_shum=50,alert=255,f_rate=A,f_dir=0,b_f_rate=5,b_f_dir=0,dfr1=5,dfr2=5,dfr3=A,dfr4=5,dfr5=5,dfr6=3,dfr7=5,dfrh=5,dfd1=0,dfd2=0,dfd3=2,dfd4=0,dfd5=0,dfd6=2,dfd7=0,dfdh=0,dmnd_run=0,en_demand=0",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_day_power_ex",
+        method_pattern="GET",
+        response="ret=OK,curr_day_heat=0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0,prev_1day_heat=0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0,curr_day_cool=0/0/0/0/0/0/0/0/0/0/1/0/0/0/0/0/0/0/0/0/0/0/0/0,prev_1day_cool=0/1/0/1/0/1/0/1/0/2/3/2/3/1/0/0/0/0/5/1/0/1/1/0",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_week_power",
+        method_pattern="GET",
+        response="ret=OK,today_runtime=38,datas=5700/4000/6100/3900/2200/3400/400",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_year_power",
+        method_pattern="GET",
+        response="ret=OK,previous_year=7/0/1/0/1/21/57/24/2/0/0/2,this_year=4/0/0/0/1/18/40/53",
+    )
+
+    device = await DaikinFactory("192.168.1.100")
+
+    assert isinstance(device, DaikinBRP069)
+    assert device._own_session is True
+    session = device.session
+    assert not session.closed
+
+    await device.aclose()
+
+    assert session.closed
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_factory_does_not_close_external_session(aresponses, client_session):
+    """A caller-provided session is not closed by aclose()."""
+    # Mock 404 for firmware 2.8.0 attempt (to force fallback)
+    aresponses.add(
+        path_pattern="/dsiot/multireq",
+        method_pattern="POST",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+
+    # Mock BRP069 responses (detection phase)
+    aresponses.add(
+        path_pattern="/common/basic_info",
+        method_pattern="GET",
+        response="ret=OK,type=aircon,reg=eu,dst=1,ver=1_2_54,rev=203DE8C,pow=1,err=0,location=0,name=%4e%6f%74%74%65,icon=3,method=home only,port=30050,id=,pw=,lpw_flag=0,adp_kind=3,pv=3.20,cpv=3,cpv_minor=20,led=1,en_setzone=1,mac=409F38D107AC,adp_mode=run,en_hol=0,ssid1=Pinguino Curioso,radio1=-35,grp_name=,en_grp=0",
+    )
+    # Mock BRP069 init responses (basic_info is skipped due to caching from detection)
+    aresponses.add(
+        path_pattern="/common/get_datetime",
+        method_pattern="GET",
+        response="ret=OK,sta=2,cur=2023/8/27 21:54:1,reg=eu,dst=1,zone=313",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_sensor_info",
+        method_pattern="GET",
+        response="ret=OK,htemp=25.0,hhum=-,otemp=21.0,err=0,cmpfreq=40",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_model_info",
+        method_pattern="GET",
+        response="ret=OK,model=0000,type=N,pv=3.20,cpv=3,cpv_minor=20,mid=NA,humd=0,s_humd=0,acled=0,land=0,elec=1,temp=1,temp_rng=0,m_dtct=1,ac_dst=--,disp_dry=0,dmnd=1,en_scdltmr=1,en_frate=1,en_fdir=1,s_fdir=3,en_rtemp_a=0,en_spmode=7,en_ipw_sep=1,en_mompow=0,hmlmt_l=10.0",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_control_info",
+        method_pattern="GET",
+        response="ret=OK,pow=1,mode=2,adv=,stemp=M,shum=50,dt1=25.0,dt2=M,dt3=25.0,dt4=25.0,dt5=25.0,dt7=25.0,dh1=AUTO,dh2=50,dh3=0,dh4=0,dh5=0,dh7=AUTO,dhh=50,b_mode=2,b_stemp=M,b_shum=50,alert=255,f_rate=A,f_dir=0,b_f_rate=5,b_f_dir=0,dfr1=5,dfr2=5,dfr3=A,dfr4=5,dfr5=5,dfr6=3,dfr7=5,dfrh=5,dfd1=0,dfd2=0,dfd3=2,dfd4=0,dfd5=0,dfd6=2,dfd7=0,dfdh=0,dmnd_run=0,en_demand=0",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_day_power_ex",
+        method_pattern="GET",
+        response="ret=OK,curr_day_heat=0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0,prev_1day_heat=0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0,curr_day_cool=0/0/0/0/0/0/0/0/0/0/1/0/0/0/0/0/0/0/0/0/0/0/0/0,prev_1day_cool=0/1/0/1/0/1/0/1/0/2/3/2/3/1/0/0/0/0/5/1/0/1/1/0",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_week_power",
+        method_pattern="GET",
+        response="ret=OK,today_runtime=38,datas=5700/4000/6100/3900/2200/3400/400",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_year_power",
+        method_pattern="GET",
+        response="ret=OK,previous_year=7/0/1/0/1/21/57/24/2/0/0/2,this_year=4/0/0/0/1/18/40/53",
+    )
+
+    device = await DaikinFactory("192.168.1.100", session=client_session)
+
+    assert isinstance(device, DaikinBRP069)
+    assert device.session is client_session
+    assert device._own_session is False
+
+    await device.aclose()
+
+    assert not client_session.closed
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -11,6 +11,7 @@ from pydaikin.daikin_brp069 import DaikinBRP069
 from pydaikin.daikin_brp072c import DaikinBRP072C
 from pydaikin.daikin_brp084 import DaikinBRP084
 from pydaikin.daikin_skyfi import DaikinSkyFi
+from pydaikin.exceptions import DaikinException
 from pydaikin.factory import DaikinFactory
 
 
@@ -663,3 +664,68 @@ async def test_factory_does_not_close_external_session(aresponses, client_sessio
 
     aresponses.assert_all_requests_matched()
     aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_factory_closes_session_on_unsupported_device(aresponses, monkeypatch):
+    """The factory closes the session it created when device creation fails."""
+    closed_sessions = []
+    original_close = ClientSession.close
+
+    async def recording_close(self):
+        closed_sessions.append(self)
+        await original_close(self)
+
+    monkeypatch.setattr(ClientSession, "close", recording_close)
+
+    # Mock 404 for firmware 2.8.0 attempt (to force fallback)
+    aresponses.add(
+        path_pattern="/dsiot/multireq",
+        method_pattern="POST",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+
+    # Mock 404 for BRP069 attempt (to force fallback to AirBase)
+    aresponses.add(
+        path_pattern="/common/basic_info",
+        method_pattern="GET",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+
+    # Mock AirBase responses that report no mode -> device is unsupported
+    aresponses.add(
+        path_pattern="/skyfi/common/get_datetime",
+        method_pattern="GET",
+        response="ret=OK,sta=2,cur=2023/8/27 21:54:1,reg=eu,dst=1,zone=313",
+    )
+    aresponses.add(
+        path_pattern="/skyfi/common/basic_info",
+        method_pattern="GET",
+        response="ret=OK,type=aircon,reg=eu,dst=1,ver=1_2_54,rev=203DE8C,pow=1,err=0,location=0,name=%4e%6f%74%74%65",
+    )
+    aresponses.add(
+        path_pattern="/skyfi/aircon/get_control_info",
+        method_pattern="GET",
+        response="ret=OK,pow=0",
+    )
+    aresponses.add(
+        path_pattern="/skyfi/aircon/get_model_info",
+        method_pattern="GET",
+        response="ret=OK,model=0000",
+    )
+    aresponses.add(
+        path_pattern="/skyfi/aircon/get_sensor_info",
+        method_pattern="GET",
+        response="ret=OK,htemp=25.0",
+    )
+    aresponses.add(
+        path_pattern="/skyfi/aircon/get_zone_setting",
+        method_pattern="GET",
+        response="ret=OK",
+    )
+
+    with pytest.raises(DaikinException, match="not supported"):
+        await DaikinFactory("192.168.1.100")
+
+    assert len(closed_sessions) == 1
+    assert closed_sessions[0].closed


### PR DESCRIPTION
## Summary

Fixes "Unclosed client session" warnings from `aiohttp` when running the CLI (e.g. `bin/pydaikin -l`).

Two separate leaks were fixed:

### 1. CLI never closed its devices (`bin/pydaikin`)
`list_all_devices()` and `main()` created appliances via `DaikinFactory` (which creates its own `ClientSession` when none is given) but never closed them. Both paths now call `aclose()` in a `finally` block.

### 2. Factory detection trials leaked sessions (`pydaikin/factory.py`)
When no external session is provided, each detection trial (BRP084 -> BRP069 -> AirBase) created its **own** `ClientSession`; failed trials were discarded without closing theirs, leaving one session open per device. The factory now creates a **single** shared session for all trials, marks the returned appliance as owning it, and closes it if device creation fails. Externally provided sessions are never closed.

`aclose()` in `daikin_base.py` already only closes the session when the appliance created it (`_own_session`), so external sessions are left untouched.

## Tests
- `test_factory_owns_and_closes_created_session`: factory-created session is owned and closed by `aclose()`.
- `test_factory_does_not_close_external_session`: caller-provided session is not closed by `aclose()`.

All tests pass (217 passed, 10 pre-existing skips), ruff and pylint are clean.