### PR TITLE
fix: clearly report unsupported BRP069C8x firmware 2.3.x

### DIFF
--- a/pydaikin/factory.py
+++ b/pydaikin/factory.py
@@ -105,9 +105,7 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
             if not already_initialized:
                 await obj.init()
             if not obj.values.get("mode"):
-                raise DaikinException(
-                    f"Error creating device, {device_id} is not supported."
-                )
+                raise DaikinException(self._unsupported_device_message(obj, device_id))
         except Exception:
             if own_session:
                 await obj.aclose()
@@ -142,6 +140,50 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
         except (DaikinException, aiohttp.ClientError, TimeoutError, OSError) as err:
             _LOGGER.debug(err)
             return None
+
+    @staticmethod
+    def _unsupported_device_message(obj: Appliance, device_id: str) -> str:
+        """Build a clear error message for a detected but unsupported device.
+
+        Some adapters answer /common/basic_info (so type, subtype and firmware
+        are known) but expose no control API. A known example is the BRP069C8x
+        running firmware 2.3.x, which returns 404 for every /aircon endpoint.
+        """
+        values = obj.values
+        device_type = values.get("type", invalidate=False)
+        subtype = values.get("subtype", invalidate=False)
+        firmware = values.get("ver", invalidate=False)
+
+        if (
+            device_type == "aircon"
+            and subtype == "qa"
+            and firmware
+            and firmware.startswith("2_3_")
+        ):
+            return (
+                f"Error creating device, {device_id} is not supported: "
+                f"BRP069C8x with firmware {firmware.replace('_', '.')} is not "
+                "supported by pydaikin."
+            )
+
+        details = []
+        if device_type:
+            details.append(f"type={device_type}")
+        if subtype:
+            details.append(f"subtype={subtype}")
+        if firmware:
+            details.append(f"firmware {firmware.replace('_', '.')}")
+        if adp_kind := values.get("adp_kind", invalidate=False):
+            details.append(f"adp_kind={adp_kind}")
+
+        if details:
+            return (
+                f"Error creating device, {device_id} is not supported: "
+                f"detected {', '.join(details)}, but its control API is not "
+                "available. This device/firmware combination is not supported "
+                "by pydaikin."
+            )
+        return f"Error creating device, {device_id} is not supported."
 
     @staticmethod
     def _extract_ip_port(device_id: str) -> Tuple[str, Optional[int]]:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -277,7 +277,89 @@ async def test_factory_detects_brp069(aresponses, client_session):
 
 
 @pytest.mark.asyncio
-async def test_factory_detects_airbase(aresponses, client_session):
+async def test_factory_unsupported_brp069c8x_firmware_230(aresponses, client_session):
+    """BRP069C8x firmware 2.3.0 (type=aircon, subtype=qa) reports a clear error."""
+    # Mock 404 response for firmware 2.8.0 attempt (to force fallback)
+    aresponses.add(
+        path_pattern="/dsiot/multireq",
+        method_pattern="POST",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+
+    # BRP069C8x answers /common/basic_info but all /aircon endpoints 404
+    aresponses.add(
+        path_pattern="/common/basic_info",
+        method_pattern="GET",
+        response="ret=OK,type=aircon,subtype=qa,reg=eu,dst=1,ver=2_3_0,rev=F45236EA,pow=0,err=0,location=0,name=%44%61%69%6b%69%6e%20%52%45,icon=31,method=polling,port=30050,id=,lpw_flag=0,adp_kind=4,pv=0,cpv=0,led=1,en_setzone=1,mac=409F38D107AC,ssid=Daikin,adp_mode=ap_run,en_hol=0,grp_name=,en_grp=0,edid=0000000003708559,sw_id=19002959,pw=,ssid1=Daikin,radio1=-52",
+    )
+    aresponses.add(
+        path_pattern="/common/get_datetime",
+        method_pattern="GET",
+        response="ret=OK,sta=2,cur=2026/5/27 15:16:44,reg=eu,dst=1,zone=211",
+    )
+    for endpoint in (
+        "/aircon/get_sensor_info",
+        "/aircon/get_model_info",
+        "/aircon/get_control_info",
+        "/aircon/get_day_power_ex",
+        "/aircon/get_week_power",
+        "/aircon/get_year_power",
+    ):
+        aresponses.add(
+            path_pattern=endpoint,
+            method_pattern="GET",
+            response=aresponses.Response(status=404, text="Page Not Found"),
+        )
+
+    with pytest.raises(
+        DaikinException, match="BRP069C8x with firmware 2.3.0 is not supported"
+    ):
+        await DaikinFactory("192.168.1.100", session=client_session)
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_factory_unsupported_unknown_device_reports_details(
+    aresponses, client_session
+):
+    """An unsupported device without known fingerprint still reports detected info."""
+    # Mock 404 response for firmware 2.8.0 attempt (to force fallback)
+    aresponses.add(
+        path_pattern="/dsiot/multireq",
+        method_pattern="POST",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+    aresponses.add(
+        path_pattern="/common/basic_info",
+        method_pattern="GET",
+        response="ret=OK,type=aircon,reg=eu,dst=1,ver=1_2_54,rev=203DE8C,pow=1,err=0,location=0,name=%4e%6f%74%74%65,icon=3,method=home only,port=30050,id=,pw=,lpw_flag=0,adp_kind=3,pv=3.20,cpv=3,cpv_minor=20,led=1,en_setzone=1,mac=409F38D107AC,adp_mode=run,en_hol=0,ssid1=Pinguino Curioso,radio1=-35,grp_name=,en_grp=0",
+    )
+    aresponses.add(
+        path_pattern="/common/get_datetime",
+        method_pattern="GET",
+        response="ret=OK,sta=2,cur=2023/8/27 21:54:1,reg=eu,dst=1,zone=313",
+    )
+    for endpoint in (
+        "/aircon/get_sensor_info",
+        "/aircon/get_model_info",
+        "/aircon/get_control_info",
+        "/aircon/get_day_power_ex",
+        "/aircon/get_week_power",
+        "/aircon/get_year_power",
+    ):
+        aresponses.add(
+            path_pattern=endpoint,
+            method_pattern="GET",
+            response=aresponses.Response(status=404, text="Page Not Found"),
+        )
+
+    with pytest.raises(
+        DaikinException,
+        match="detected type=aircon, firmware 1.2.54, adp_kind=3.*not supported",
+    ):
+        await DaikinFactory("192.168.1.100", session=client_session)
     """Test that factory correctly detects AirBase device (fallback from BRP069)."""
     # Mock 404 response for firmware 2.8.0 attempt
     aresponses.add(

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,6 +1,7 @@
 """Test the DaikinFactory for proper device type detection."""
 
 import json
+from types import SimpleNamespace
 
 from aiohttp import ClientSession
 import pytest
@@ -334,7 +335,7 @@ async def test_factory_unsupported_unknown_device_reports_details(
     aresponses.add(
         path_pattern="/common/basic_info",
         method_pattern="GET",
-        response="ret=OK,type=aircon,reg=eu,dst=1,ver=1_2_54,rev=203DE8C,pow=1,err=0,location=0,name=%4e%6f%74%74%65,icon=3,method=home only,port=30050,id=,pw=,lpw_flag=0,adp_kind=3,pv=3.20,cpv=3,cpv_minor=20,led=1,en_setzone=1,mac=409F38D107AC,adp_mode=run,en_hol=0,ssid1=Pinguino Curioso,radio1=-35,grp_name=,en_grp=0",
+        response="ret=OK,type=aircon,subtype=qa,reg=eu,dst=1,ver=1_2_54,rev=203DE8C,pow=1,err=0,location=0,name=%4e%6f%74%74%65,icon=3,method=home only,port=30050,id=,pw=,lpw_flag=0,adp_kind=3,pv=3.20,cpv=3,cpv_minor=20,led=1,en_setzone=1,mac=409F38D107AC,adp_mode=run,en_hol=0,ssid1=Pinguino Curioso,radio1=-35,grp_name=,en_grp=0",
     )
     aresponses.add(
         path_pattern="/common/get_datetime",
@@ -355,11 +356,30 @@ async def test_factory_unsupported_unknown_device_reports_details(
             response=aresponses.Response(status=404, text="Page Not Found"),
         )
 
+    # subtype=qa alone is not the unsupported fingerprint (firmware is 1.2.x),
+    # but it is still reported in the error details.
     with pytest.raises(
         DaikinException,
-        match="detected type=aircon, firmware 1.2.54, adp_kind=3.*not supported",
+        match="detected type=aircon, subtype=qa, firmware 1.2.54, adp_kind=3.*not supported",
     ):
         await DaikinFactory("192.168.1.100", session=client_session)
+
+
+def test_unsupported_device_message_without_identity():
+    """The fallback message is used when no device identity was detected."""
+    fake_values = SimpleNamespace(
+        get=lambda key, default=None, *, invalidate=True: default
+    )
+    fake_device = SimpleNamespace(values=fake_values)
+
+    assert (
+        DaikinFactory._unsupported_device_message(fake_device, "192.168.1.100")
+        == "Error creating device, 192.168.1.100 is not supported."
+    )
+
+
+@pytest.mark.asyncio
+async def test_factory_detects_airbase(aresponses, client_session):
     """Test that factory correctly detects AirBase device (fallback from BRP069)."""
     # Mock 404 response for firmware 2.8.0 attempt
     aresponses.add(


### PR DESCRIPTION
## Summary

Fixes #116.

Devices like the **BRP069C8x** running firmware **2.3.x** answer `/common/basic_info` (reporting `type=aircon`, `subtype=qa`, `ver=2_3_0`, `adp_kind=4`) but return `404 Not Found` for every `/aircon/...` control endpoint. Setup therefore failed with the generic message:

```
Error creating device, 192.168.50.10 is not supported.
```

## Changes

`pydaikin/factory.py` — when a device exposes no control API (no `mode`), the factory now raises an informative error via a new `_unsupported_device_message()` helper:

- Detects the known unsupported combination (`type=aircon` + `subtype=qa` + firmware `2_3_*`) and reports:

  ```
  Error creating device, 192.168.50.10 is not supported: BRP069C8x with firmware 2.3.0 is not supported by pydaikin.
  ```

- For other unsupported devices, includes whatever was detected from `/common/basic_info` (`type`, `subtype`, `firmware`, `adp_kind`) so the message is actionable:

  ```
  Error creating device, X is not supported: detected type=aircon, subtype=..., firmware 1.2.54, adp_kind=3, but its control API is not available. This device/firmware combination is not supported by pydaikin.
  ```

This works because the BRP069 detection phase already caches `/common/basic_info`, so the identifying values are available at the point the final error is raised.

## Tests

- `test_factory_unsupported_brp069c8x_firmware_230` — reproduces the exact issue #116 responses and asserts the new message.
- `test_factory_unsupported_unknown_device_reports_details` — asserts generic devices still get a descriptive error.

`pytest`: 294 passed / 4 skipped. pre-commit hooks pass.