### PR TITLE
fix: fan-rate capability for AirBase Linear Zone controllers

### DIFF
--- a/pydaikin/daikin_airbase.py
+++ b/pydaikin/daikin_airbase.py
@@ -84,6 +84,15 @@ class DaikinAirBase(DaikinBRP069):
         return False
 
     @property
+    def support_fan_rate(self) -> bool:
+        """Return whether the device supports manual fan-rate control."""
+        return (
+            super().support_fan_rate
+            and self.values.get("en_frate") != "0"
+            and self.values.get("en_linear_zone") != "1"
+        )
+
+    @property
     def support_outside_temperature(self):
         """Return True if the device reports an outside temperature."""
         return 'otemp' in self.values and self.values['otemp'] != '-'

--- a/tests/test_daikin_airbase.py
+++ b/tests/test_daikin_airbase.py
@@ -181,6 +181,23 @@ def test_support_outside_temperature(values, expected):
 
 
 @pytest.mark.parametrize(
+    "values, expected",
+    [
+        ({"f_rate": "5", "en_frate": "1", "en_linear_zone": "0"}, True),
+        ({"f_rate": "5", "en_frate": "1", "en_linear_zone": "1"}, False),
+        ({"f_rate": "5", "en_frate": "0", "en_linear_zone": "0"}, False),
+        ({"f_rate": "5"}, True),
+        ({"en_frate": "1", "en_linear_zone": "0"}, False),
+    ],
+)
+def test_support_fan_rate(values, expected):
+    """Test manual fan-rate support for AirBase controllers."""
+    device = DaikinAirBase("127.0.0.1", session=MagicMock())
+    device.values.update(values)
+    assert device.support_fan_rate is expected
+
+
+@pytest.mark.parametrize(
     'values, expected',
     [
         ({'otemp': '40'}, 40.0),


### PR DESCRIPTION
## Description

Fix AirBase fan-rate capability reporting for AirHub Linear Zone controllers.

Some Linear Zone controllers report both a current `f_rate` and `en_frate=1`, even though their OptiZone control owns the indoor fan speed and does not offer manual fan settings. Because `support_fan_rate` previously relied only on the presence of `f_rate`, clients such as Home Assistant could expose a fan-speed control that the controller cannot apply.

Override `support_fan_rate` for AirBase devices so manual fan-rate control is reported only when:

- the controller reports an `f_rate`;
- `en_frate` does not explicitly disable fan-rate control; and
- `en_linear_zone` does not identify a Linear Zone controller.

The fallback based on `f_rate` is retained for older controllers that do not report the capability flags.

An affected controller reported `en_linear_zone=1`, `en_frate=1`, `en_frate_auto=1`, and `frate_steps=3`. This combination describes an indoor unit with fan-rate capability whose fan speed is managed automatically by the Linear/OptiZone controller.

### Supporting documentation

- Daikin's [AirHub Touch Zone Controller operation manual](https://www.daikin.com.au/sites/default/files/daikin-ducted-air-conditioning-Daikin-AirHub-BRCM%28S%29TZCB.pdf), section 8, "Fan Operation" (page 37), states that fan settings are only available for On/Off control and that airflow is automatically controlled on the Linear control version.
- Daikin's [OptiZone FAQ](https://www.daikin.com.au/faq/controllers/whats-optizone-airhub-controller) explains that OptiZone automatically regulates zone dampers and intelligently regulates indoor fan speed between 30–100% of nominal airflow.
- Daikin's [AirHub controller overview](https://www.daikin.com.au/article/daikin-introduces-airhub-touch-zone-controller-for-homes) distinguishes On/Off Zone Control from Linear Zone Control and explains that the Linear version uses OptiZone to adjust fan and compressor output automatically.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this with real Daikin hardware (if applicable)

Validation performed:

- `pytest tests/test_daikin_airbase.py` — 33 passed
- `pytest` — 301 passed, 4 skipped
- `pre-commit run --all-files` — Ruff, Ruff format, and Pylint passed

## Code Quality

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)

## String Formatting (New Code)

- [x] If this PR adds new Python files, I've used double quotes (`"`) for strings following Python conventions

> **Note:** An automated check will highlight single quotes in new code. We're planning to migrate to standard string normalization in the future. New code should prefer double quotes (`"`) over single quotes (`'`) to ease this transition.

## Documentation

- [ ] I have updated the documentation accordingly (if needed)
- [ ] I have updated the CHANGELOG (if applicable)

## Related Issues

No linked issue.

## Additional Notes

The reported `f_rate` remains available as device state. This change only prevents integrations from advertising unsupported manual fan-rate control.
