### PR TITLE
feat: add demand control support for BRP069 units

### DIFF
--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -580,7 +580,7 @@ class Appliance(DaikinPowerMixin):
         """Enable or disable the streamer."""
         raise NotImplementedError
 
-    async def get_demand_control(self):
+    def get_demand_control(self):
         """Get demand control settings from the device."""
         raise NotImplementedError
 

--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -589,8 +589,14 @@ class Appliance(DaikinPowerMixin):
 
         Args:
             en_demand: Enable ("on") or disable ("off") demand control.
-            max_pow: Maximum power as a percentage of the unit's nominal power.
-            mode: Demand control mode.
+                Disabling is enough to turn it off and resets ``mode`` to 0
+                and ``max_pow`` to 100.
+            max_pow: Maximum power as a percentage of the unit's nominal
+                power (0-100).
+            mode: Demand control mode (int):
+                0 - manual: fixed ``max_pow`` limit,
+                1 - scheduled: applies a previously set schedule,
+                2 - auto: the unit manages the limit by itself.
         """
         raise NotImplementedError
 

--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -451,6 +451,11 @@ class Appliance(DaikinPowerMixin):
         return super().support_energy_consumption
 
     @property
+    def support_demand_control(self) -> bool:
+        """Return True if the device supports demand control."""
+        return False
+
+    @property
     def outside_temperature(self) -> Optional[float]:
         """Return current outside temperature."""
         return self._parse_number('otemp')
@@ -573,6 +578,20 @@ class Appliance(DaikinPowerMixin):
 
     async def set_streamer(self, mode):
         """Enable or disable the streamer."""
+        raise NotImplementedError
+
+    async def get_demand_control(self):
+        """Get demand control settings from the device."""
+        raise NotImplementedError
+
+    async def set_demand_control(self, en_demand=None, max_pow=None, mode=None):
+        """Set demand control (max power limit) on the device.
+
+        Args:
+            en_demand: Enable ("on") or disable ("off") demand control.
+            max_pow: Maximum power as a percentage of the unit's nominal power.
+            mode: Demand control mode.
+        """
         raise NotImplementedError
 
     @property

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -381,6 +381,14 @@ class DaikinBRP069(Appliance):
         demand control is supported, so the data is fetched by
         :meth:`update_status` and cached. Reading the values marks the
         resource for refresh on the next update.
+
+        Returns the raw response of the endpoint, which includes:
+        - ``en_demand``: "0" or "1", whether demand control is enabled.
+        - ``mode``: "0" (manual), "1" (scheduled) or "2" (auto).
+        - ``max_pow``: maximum power as a percentage (0-100).
+        - schedule data: ``scdl_per_day`` and per-day counts (``moc``,
+          ``tuc``, ...), plus per-event entries (``mo1_en``, ...) when a
+          schedule is set.
         """
         return self.values.values_for_resource("aircon/get_demand_control")
 
@@ -388,9 +396,15 @@ class DaikinBRP069(Appliance):
         """Set demand control (max power limit) on the device.
 
         Args:
-            en_demand: Enable ("on") or disable ("off") demand control.
-            max_pow: Maximum power as a percentage of the unit's nominal power.
-            mode: Demand control mode.
+            en_demand: Enable (``"on"``) or disable (``"off"``) demand control.
+                Disabling is enough to turn it off and resets ``mode`` to 0
+                and ``max_pow`` to 100.
+            max_pow: Maximum power as a percentage of the unit's nominal
+                power (0-100).
+            mode: Demand control mode (int):
+                0 - manual: fixed ``max_pow`` limit,
+                1 - scheduled: applies a previously set schedule,
+                2 - auto: the unit manages the limit by itself.
         """
         params = {}
         if en_demand is not None:

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -62,6 +62,10 @@ class DaikinBRP069(Appliance):
             '0': 'off',
             '1': 'on',
         },
+        "en_demand": {
+            "0": "off",
+            "1": "on",
+        },
     }
 
     # HTTP endpoints fetched during init()
@@ -225,13 +229,17 @@ class DaikinBRP069(Appliance):
 
     def get_info_resources(self):
         """Returns info_resources"""
+        resources = list(super().get_info_resources())
         if self.support_energy_consumption:
-            return self.INFO_RESOURCES + [
+            resources += [
                 'aircon/get_day_power_ex',
                 'aircon/get_week_power',
             ]
 
-        return self.INFO_RESOURCES
+        if self.support_demand_control:
+            resources.append("aircon/get_demand_control")
+
+        return resources
 
     async def _update_settings(self, settings):
         """Update settings to set on Daikin device."""
@@ -356,3 +364,42 @@ class DaikinBRP069(Appliance):
             await self._get_resource('common/get_datetime', {"cur": ""})
         except Exception as exc:  # pylint: disable=broad-except
             _LOGGER.error('Raised "%s" while trying to auto-set internal clock', exc)
+
+    @property
+    def support_demand_control(self) -> bool:
+        """Return True if the device supports demand control.
+
+        The ``dmnd`` field of ``/aircon/get_model_info`` advertises demand
+        control capability (only present on protocol >= v3 devices).
+        """
+        return self.values.get("dmnd", invalidate=False) == "1"
+
+    async def get_demand_control(self):
+        """Get demand control settings from the device."""
+        path = "aircon/get_demand_control"
+        response = await self._get_resource(path)
+        self.values.update_by_resource(path, response)
+        return response
+
+    async def set_demand_control(self, en_demand=None, max_pow=None, mode=None):
+        """Set demand control (max power limit) on the device.
+
+        Args:
+            en_demand: Enable ("on") or disable ("off") demand control.
+            max_pow: Maximum power as a percentage of the unit's nominal power.
+            mode: Demand control mode.
+        """
+        params = {}
+        if en_demand is not None:
+            params["en_demand"] = self.human_to_daikin("en_demand", en_demand)
+        if max_pow is not None:
+            params["max_pow"] = str(max_pow)
+        if mode is not None:
+            params["mode"] = str(mode)
+
+        _LOGGER.debug(
+            "Sending request to aircon/set_demand_control with params: %s", params
+        )
+        await self._get_resource("aircon/set_demand_control", params)
+        # The set response only returns ret=OK, so fetch the new state
+        await self.get_demand_control()

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -374,12 +374,15 @@ class DaikinBRP069(Appliance):
         """
         return self.values.get("dmnd", invalidate=False) == "1"
 
-    async def get_demand_control(self):
-        """Get demand control settings from the device."""
-        path = "aircon/get_demand_control"
-        response = await self._get_resource(path)
-        self.values.update_by_resource(path, response)
-        return response
+    def get_demand_control(self):
+        """Return cached demand control settings from the device.
+
+        ``aircon/get_demand_control`` is part of the info resources when
+        demand control is supported, so the data is fetched by
+        :meth:`update_status` and cached. Reading the values marks the
+        resource for refresh on the next update.
+        """
+        return self.values.values_for_resource("aircon/get_demand_control")
 
     async def set_demand_control(self, en_demand=None, max_pow=None, mode=None):
         """Set demand control (max power limit) on the device.
@@ -402,4 +405,6 @@ class DaikinBRP069(Appliance):
         )
         await self._get_resource("aircon/set_demand_control", params)
         # The set response only returns ret=OK, so fetch the new state
-        await self.get_demand_control()
+        path = "aircon/get_demand_control"
+        response = await self._get_resource(path)
+        self.values.update_by_resource(path, response)

--- a/pydaikin/daikin_skyfi.py
+++ b/pydaikin/daikin_skyfi.py
@@ -84,6 +84,12 @@ class DaikinSkyFi(Appliance):
     async def set_streamer(self, mode):
         """Set streamer mode."""
 
+    async def get_demand_control(self):
+        """Get demand control settings from the device."""
+
+    async def set_demand_control(self, en_demand=None, max_pow=None, mode=None):
+        """Set demand control (max power limit) on the device."""
+
     @property
     def support_away_mode(self):
         """Return True if the device support away_mode."""
@@ -97,6 +103,11 @@ class DaikinSkyFi(Appliance):
     @property
     def support_swing_mode(self):
         """Return True if the device support setting swing_mode."""
+        return False
+
+    @property
+    def support_demand_control(self) -> bool:
+        """Return True if the device supports demand control."""
         return False
 
     @property

--- a/pydaikin/daikin_skyfi.py
+++ b/pydaikin/daikin_skyfi.py
@@ -84,7 +84,7 @@ class DaikinSkyFi(Appliance):
     async def set_streamer(self, mode):
         """Set streamer mode."""
 
-    async def get_demand_control(self):
+    def get_demand_control(self):
         """Get demand control settings from the device."""
 
     async def set_demand_control(self, en_demand=None, max_pow=None, mode=None):

--- a/pydaikin/values.py
+++ b/pydaikin/values.py
@@ -78,3 +78,11 @@ class ApplianceValues(MutableMapping):
         self._last_update_by_resource[resource] = datetime.now(timezone.utc)
         for k in data.keys():
             self._resource_by_key[k] = resource
+
+    def values_for_resource(self, resource: str, *, invalidate: bool = True):
+        """Return the values that were last updated by the given resource."""
+        return {
+            key: self.get(key, invalidate=invalidate)
+            for key, res in self._resource_by_key.items()
+            if res == resource
+        }

--- a/pydaikin/values.py
+++ b/pydaikin/values.py
@@ -17,6 +17,7 @@ class ApplianceValues(MutableMapping):
         self._data = {}
         self._last_update_by_resource = {}
         self._resource_by_key = {}
+        self._raw_by_resource = {}
 
     # --- Implementation of abstract methods ---
 
@@ -76,13 +77,12 @@ class ApplianceValues(MutableMapping):
         """Update the values and keep track of which resource provided them."""
         self._data.update(data)
         self._last_update_by_resource[resource] = datetime.now(timezone.utc)
+        self._raw_by_resource[resource] = dict(data)
         for k in data.keys():
             self._resource_by_key[k] = resource
 
     def values_for_resource(self, resource: str, *, invalidate: bool = True):
-        """Return the values that were last updated by the given resource."""
-        return {
-            key: self.get(key, invalidate=invalidate)
-            for key, res in self._resource_by_key.items()
-            if res == resource
-        }
+        """Return the raw values of the last response of the given resource."""
+        if invalidate:
+            self.invalidate_resource(resource)
+        return dict(self._raw_by_resource.get(resource, {}))

--- a/tests/test_brp069_setters.py
+++ b/tests/test_brp069_setters.py
@@ -157,44 +157,32 @@ async def test_set_zone(aresponses, client_session):
 
 @pytest.mark.asyncio
 async def test_get_demand_control(aresponses, client_session):
-    """Test get_demand_control method."""
-    aresponses.add(
-        path_pattern="/aircon/get_demand_control",
-        method_pattern="GET",
-        response="ret=OK,type=1,en_demand=1,mode=0,max_pow=45,scdl_per_day=4,moc=0,tuc=0,wec=0,thc=0,frc=0,sac=0,suc=0",
+    """Test get_demand_control returns cached values without a request."""
+    device = DaikinBRP069("192.168.1.100", session=client_session)
+    # Data is fetched and cached by update_status
+    device.values.update_by_resource(
+        "aircon/get_demand_control",
+        {"en_demand": "1", "mode": "0", "max_pow": "45"},
     )
 
-    device = DaikinBRP069("192.168.1.100", session=client_session)
-    # Unit advertises demand control capability via model_info (dmnd)
-    device.values["dmnd"] = "1"
-    response = await device.get_demand_control()
+    response = device.get_demand_control()
 
-    assert response["max_pow"] == "45"
-    assert device.values.get("en_demand", invalidate=False) == "1"
-    assert device.values.get("max_pow", invalidate=False) == "45"
-    assert device.support_demand_control is True
+    assert response == {"en_demand": "1", "mode": "0", "max_pow": "45"}
 
-    aresponses.assert_all_requests_matched()
+    # No HTTP request should be made (no routes are registered)
 
 
 @pytest.mark.asyncio
 async def test_get_demand_control_unsupported(aresponses, client_session):
     """Test get_demand_control on a device that does not support it."""
-    aresponses.add(
-        path_pattern="/aircon/get_demand_control",
-        method_pattern="GET",
-        response=aresponses.Response(status=404, text="Not Found"),
-    )
-
     device = DaikinBRP069("192.168.1.100", session=client_session)
     # Unit does not advertise demand control capability via model_info (dmnd)
     device.values["dmnd"] = "0"
-    response = await device.get_demand_control()
+
+    response = device.get_demand_control()
 
     assert response == {}
     assert device.support_demand_control is False
-
-    aresponses.assert_all_requests_matched()
 
 
 @pytest.mark.asyncio

--- a/tests/test_brp069_setters.py
+++ b/tests/test_brp069_setters.py
@@ -153,3 +153,113 @@ async def test_set_zone(aresponses, client_session):
 
     # Should not fail, just do nothing
     await device.set_zone(1, 'key', 'value')
+
+
+@pytest.mark.asyncio
+async def test_get_demand_control(aresponses, client_session):
+    """Test get_demand_control method."""
+    aresponses.add(
+        path_pattern="/aircon/get_demand_control",
+        method_pattern="GET",
+        response="ret=OK,type=1,en_demand=1,mode=0,max_pow=45,scdl_per_day=4,moc=0,tuc=0,wec=0,thc=0,frc=0,sac=0,suc=0",
+    )
+
+    device = DaikinBRP069("192.168.1.100", session=client_session)
+    # Unit advertises demand control capability via model_info (dmnd)
+    device.values["dmnd"] = "1"
+    response = await device.get_demand_control()
+
+    assert response["max_pow"] == "45"
+    assert device.values.get("en_demand", invalidate=False) == "1"
+    assert device.values.get("max_pow", invalidate=False) == "45"
+    assert device.support_demand_control is True
+
+    aresponses.assert_all_requests_matched()
+
+
+@pytest.mark.asyncio
+async def test_get_demand_control_unsupported(aresponses, client_session):
+    """Test get_demand_control on a device that does not support it."""
+    aresponses.add(
+        path_pattern="/aircon/get_demand_control",
+        method_pattern="GET",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+
+    device = DaikinBRP069("192.168.1.100", session=client_session)
+    # Unit does not advertise demand control capability via model_info (dmnd)
+    device.values["dmnd"] = "0"
+    response = await device.get_demand_control()
+
+    assert response == {}
+    assert device.support_demand_control is False
+
+    aresponses.assert_all_requests_matched()
+
+
+@pytest.mark.asyncio
+async def test_set_demand_control(aresponses, client_session):
+    """Test set_demand_control method."""
+    aresponses.add(
+        path_pattern="/aircon/set_demand_control",
+        method_pattern="GET",
+        response="ret=OK",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_demand_control",
+        method_pattern="GET",
+        response="ret=OK,type=1,en_demand=1,mode=0,max_pow=40,scdl_per_day=4,moc=0,tuc=0,wec=0,thc=0,frc=0,sac=0,suc=0",
+    )
+
+    device = DaikinBRP069("192.168.1.100", session=client_session)
+    await device.set_demand_control(en_demand="1", max_pow=40, mode="0")
+
+    # Verify the set request carried the right query params
+    request = aresponses.history[0].request
+    assert request.path == "/aircon/set_demand_control"
+    assert request.query["en_demand"] == "1"
+    assert request.query["max_pow"] == "40"
+    assert request.query["mode"] == "0"
+
+    # State should be refreshed from the follow-up get request
+    assert device.values.get("max_pow", invalidate=False) == "40"
+
+    aresponses.assert_all_requests_matched()
+
+
+@pytest.mark.asyncio
+async def test_set_demand_control_human_values(aresponses, client_session):
+    """Test set_demand_control maps human values to Daikin values."""
+    aresponses.add(
+        path_pattern="/aircon/set_demand_control",
+        method_pattern="GET",
+        response="ret=OK",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_demand_control",
+        method_pattern="GET",
+        response="ret=OK,type=1,en_demand=1,mode=0,max_pow=30,scdl_per_day=4,moc=0,tuc=0,wec=0,thc=0,frc=0,sac=0,suc=0",
+    )
+
+    device = DaikinBRP069("192.168.1.100", session=client_session)
+    await device.set_demand_control(en_demand="on", max_pow=30)
+
+    request = aresponses.history[0].request
+    assert request.query["en_demand"] == "1"
+    assert request.query["max_pow"] == "30"
+
+    aresponses.assert_all_requests_matched()
+
+
+@pytest.mark.asyncio
+async def test_get_info_resources_demand_control(aresponses, client_session):
+    """Test get_info_resources includes demand control when supported."""
+    device = DaikinBRP069("192.168.1.100", session=client_session)
+
+    assert "aircon/get_demand_control" not in device.get_info_resources()
+
+    device.values["dmnd"] = "1"
+    assert "aircon/get_demand_control" in device.get_info_resources()
+
+    device.values["dmnd"] = "0"
+    assert "aircon/get_demand_control" not in device.get_info_resources()

--- a/tests/test_daikin_base.py
+++ b/tests/test_daikin_base.py
@@ -644,6 +644,8 @@ def test_show_sensors(capsys):
         ('set_holiday', ('1',)),
         ('set_advanced_mode', ('powerful', '1')),
         ('set_streamer', ('1',)),
+        ('get_demand_control', ()),
+        ('set_demand_control', ({},)),
         ('set_zone', (0, 'key', 'value')),
     ],
 )
@@ -658,6 +660,12 @@ def test_base_appliance_zones_none():
     """The base Appliance exposes no zones."""
     device = Appliance('127.0.0.1', session=MagicMock())
     assert device.zones is None
+
+
+def test_base_appliance_support_demand_control_false():
+    """The base Appliance does not support demand control."""
+    device = Appliance('127.0.0.1', session=MagicMock())
+    assert device.support_demand_control is False
 
 
 def test_subclass_missing_override_raises():

--- a/tests/test_skyfi.py
+++ b/tests/test_skyfi.py
@@ -106,3 +106,19 @@ def test_support_humidity_not_supported():
     # Add a dummy value to ensure it's not being read from the base class
     device.values.update({'hhum': '50'})
     assert device.support_humidity is False
+
+
+def test_support_demand_control_not_supported():
+    """Test that support_demand_control is always False for DaikinSkyFi."""
+    mock_session = MagicMock()
+    device = DaikinSkyFi('127.0.0.1', session=mock_session, password='dummy_password')
+    assert device.support_demand_control is False
+
+
+@pytest.mark.asyncio
+async def test_demand_control_methods_noop():
+    """Test that demand control methods are no-ops for DaikinSkyFi."""
+    mock_session = MagicMock()
+    device = DaikinSkyFi('127.0.0.1', session=mock_session, password='dummy_password')
+    assert await device.get_demand_control() is None
+    assert await device.set_demand_control(en_demand="on", max_pow=50, mode="1") is None

--- a/tests/test_skyfi.py
+++ b/tests/test_skyfi.py
@@ -120,5 +120,5 @@ async def test_demand_control_methods_noop():
     """Test that demand control methods are no-ops for DaikinSkyFi."""
     mock_session = MagicMock()
     device = DaikinSkyFi('127.0.0.1', session=mock_session, password='dummy_password')
-    assert await device.get_demand_control() is None
+    assert device.get_demand_control() is None
     assert await device.set_demand_control(en_demand="on", max_pow=50, mode="1") is None

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -197,3 +197,41 @@ def test_appliance_values_multiple_resources():
     _ = values['mode']
     assert values.should_resource_be_updated('basic_info') is True
     assert values.should_resource_be_updated('sensor_info') is False
+
+
+def test_appliance_values_values_for_resource():
+    """Test values_for_resource returns only values from the given resource."""
+    values = ApplianceValues()
+
+    values.update_by_resource(
+        "aircon/get_demand_control",
+        {"en_demand": "1", "mode": "0", "max_pow": "45"},
+    )
+    values.update_by_resource(
+        "aircon/get_control_info",
+        {"pow": "1", "stemp": "22"},
+    )
+
+    assert values.values_for_resource(
+        "aircon/get_demand_control", invalidate=False
+    ) == {
+        "en_demand": "1",
+        "mode": "0",
+        "max_pow": "45",
+    }
+    assert values.values_for_resource("aircon/get_control_info", invalidate=False) == {
+        "pow": "1",
+        "stemp": "22",
+    }
+    assert values.values_for_resource("aircon/unknown", invalidate=False) == {}
+
+
+def test_appliance_values_values_for_resource_invalidates():
+    """Test values_for_resource invalidates the resource by default."""
+    values = ApplianceValues()
+
+    values.update_by_resource("aircon/get_demand_control", {"en_demand": "1"})
+    assert values.should_resource_be_updated("aircon/get_demand_control") is False
+
+    values.values_for_resource("aircon/get_demand_control")
+    assert values.should_resource_be_updated("aircon/get_demand_control") is True

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -200,21 +200,25 @@ def test_appliance_values_multiple_resources():
 
 
 def test_appliance_values_values_for_resource():
-    """Test values_for_resource returns only values from the given resource."""
+    """Test values_for_resource returns the raw response of the given resource."""
     values = ApplianceValues()
 
     values.update_by_resource(
         "aircon/get_demand_control",
-        {"en_demand": "1", "mode": "0", "max_pow": "45"},
+        {"ret": "OK", "en_demand": "1", "mode": "0", "max_pow": "45"},
     )
     values.update_by_resource(
         "aircon/get_control_info",
-        {"pow": "1", "stemp": "22"},
+        {"pow": "1", "stemp": "22", "mode": "2"},
     )
 
+    # mode is shared by both resources: the flat cache only keeps the last one,
+    # but values_for_resource returns the exact response of the resource.
+    assert values["mode"] == "2"
     assert values.values_for_resource(
         "aircon/get_demand_control", invalidate=False
     ) == {
+        "ret": "OK",
         "en_demand": "1",
         "mode": "0",
         "max_pow": "45",
@@ -222,6 +226,7 @@ def test_appliance_values_values_for_resource():
     assert values.values_for_resource("aircon/get_control_info", invalidate=False) == {
         "pow": "1",
         "stemp": "22",
+        "mode": "2",
     }
     assert values.values_for_resource("aircon/unknown", invalidate=False) == {}
 


### PR DESCRIPTION
Closes #139

## Summary

Adds support for the Daikin demand control feature (limiting the maximum power of the unit) exposed via:

- `GET /aircon/get_demand_control`
- `POST/GET /aircon/set_demand_control` (called via GET with query params, consistent with the other BRP069 set endpoints)

This enables use cases like capping AC power during peak/high-rate electricity periods (e.g. French Tempo red days).

## Changes

- `pydaikin/daikin_brp069.py`:
  - `get_demand_control()` — fetches current demand control state (`en_demand`, `max_pow`, `mode`, schedule slots) into `values`.
  - `set_demand_control(en_demand, max_pow, mode)` — applies the limit and refreshes the state via a follow-up get (the set endpoint only returns `ret=OK`).
  - `support_demand_control` property — capability is advertised by the `dmnd` field of `/aircon/get_model_info` (only present on protocol >= v3 units).
  - `get_info_resources()` now includes `aircon/get_demand_control` when supported, so the state is kept fresh by normal polling.
  - `en_demand` translation (`0/1` -> `off/on`).
- `tests/test_brp069_setters.py` — coverage for get/set, human-value mapping, 404/unsupported handling, and resource selection.

## Notes

- The GET-vs-POST behaviour of `set_demand_control` should be confirmed against a real BRP069B4x unit; it is sent as GET (with query params), matching how the other set endpoints are called in this codebase.
- Support detection uses the `dmnd` model_info flag rather than probing the endpoint, avoiding an extra HTTP request on every device init.