### PR TITLE
Add BRP084 dry comfort offset support

### DIFF
--- a/pydaikin/daikin_brp084.py
+++ b/pydaikin/daikin_brp084.py
@@ -113,6 +113,7 @@ class DaikinBRP084(Appliance):
         # Powerful (outdoor e_3002/p_44): 00=off, 01=on. Verified live
         # read+write; the unit also auto-cancels after ~20 min.
         "powerful": E_1003_PATH + ["e_3002", "p_44"],
+        "dry_comfort_offset": E_1002_E_3001_PATH + ["p_34"],
         # Outdoor unit sensors (read-only)
         "compressor_temp": E_1003_PATH + ["e_A005", "p_01"],
         "discharge_temp": E_1003_PATH + ["e_A005", "p_02"],
@@ -312,6 +313,23 @@ class DaikinBRP084(Appliance):
     def hex_le_to_temp(cls, value: str, divisor=2) -> float:
         """Convert a little-endian signed hex temperature to degrees Celsius."""
         return cls.hex_le_to_int(value, signed=True) / divisor
+
+    @staticmethod
+    def hex_to_dry_comfort_offset(value: str) -> float:
+        """Convert a signed one-byte dry comfort offset to degrees Celsius."""
+        raw = bytes.fromhex(value[:2])
+        return int.from_bytes(raw, byteorder='big', signed=True) / 2
+
+    @staticmethod
+    def dry_comfort_offset_to_hex(offset: float) -> str:
+        """Convert a dry comfort offset in degrees Celsius to signed hex."""
+        value = float(offset)
+        doubled = value * 2
+        if value < -3.0 or value > 0.0 or abs(doubled - round(doubled)) > 1e-9:
+            raise ValueError("Dry comfort offset must be -3.0..0.0 in 0.5 steps")
+        return (
+            int(round(doubled)).to_bytes(1, byteorder='big', signed=True).hex().upper()
+        )
 
     @staticmethod
     def hex_to_ascii(value: str) -> str:
@@ -540,6 +558,18 @@ class DaikinBRP084(Appliance):
         except DaikinException:
             pass
 
+        # Dry-mode comfort offset (STD +/- bias), not a normal target temp.
+        try:
+            self.values['dry_comfort_offset'] = str(
+                self.hex_to_dry_comfort_offset(
+                    self.find_value_by_pn(
+                        response, *self.get_path("dry_comfort_offset")
+                    )
+                )
+            )
+        except (DaikinException, ValueError):
+            pass
+
         # Adapter capability flags. The firmware version ('ver') is already
         # read in update_status from the same adp_i path.
         try:
@@ -670,6 +700,22 @@ class DaikinBRP084(Appliance):
         temp_hex = self.temp_to_hex(float(settings['stemp']))
         self.add_request(requests, path, temp_hex)
 
+    def _handle_dry_comfort_offset_setting(self, settings, requests):
+        """Handle dry-mode comfort offset settings."""
+        if 'dry_comfort_offset' not in settings or self.values.get('mode') != 'dry':
+            return
+
+        path = self.get_path("dry_comfort_offset")
+        try:
+            offset_hex = self.dry_comfort_offset_to_hex(settings['dry_comfort_offset'])
+        except (TypeError, ValueError):
+            _LOGGER.warning(
+                "Invalid dry comfort offset %r; no write will be sent",
+                settings['dry_comfort_offset'],
+            )
+            return
+        self.add_request(requests, path, offset_hex)
+
     def _handle_fan_setting(self, settings, requests):
         """Handle fan-related settings."""
         if (
@@ -790,6 +836,7 @@ class DaikinBRP084(Appliance):
         # Handle different types of settings
         self._handle_power_setting(settings, requests)
         self._handle_temperature_setting(settings, requests)
+        self._handle_dry_comfort_offset_setting(settings, requests)
         self._handle_fan_setting(settings, requests)
         # vane_vertical takes precedence over swing for the vertical axis, so
         # handle swing first and let an explicit vane position override it.
@@ -858,6 +905,20 @@ class DaikinBRP084(Appliance):
     async def set_vertical_vane(self, position):
         """Set the vertical vane position ('off'/'down'/'swing')."""
         await self.set({'vane_vertical': position})
+
+    @property
+    def dry_comfort_offset(self) -> Optional[float]:
+        """Return dry-mode comfort offset in degrees Celsius."""
+        return self._parse_number('dry_comfort_offset')
+
+    @property
+    def support_dry_comfort_offset(self) -> bool:
+        """Return True if the device exposes dry-mode comfort offset."""
+        return 'dry_comfort_offset' in self.values
+
+    async def set_dry_comfort_offset(self, offset):
+        """Set the dry-mode comfort offset in degrees Celsius."""
+        await self.set({'dry_comfort_offset': offset})
 
     async def set_econo_mode(self, mode):
         """Enable or disable Econo mode ('on'/'off')."""

--- a/pydaikin/daikin_brp084.py
+++ b/pydaikin/daikin_brp084.py
@@ -318,7 +318,7 @@ class DaikinBRP084(Appliance):
     def hex_to_dry_comfort_offset(value: str) -> float:
         """Convert a signed one-byte dry comfort offset to degrees Celsius."""
         raw = bytes.fromhex(value[:2])
-        return int.from_bytes(raw, byteorder='big', signed=True) / 2
+        return int.from_bytes(raw, byteorder="big", signed=True) / 2
 
     @staticmethod
     def dry_comfort_offset_to_hex(offset: float) -> str:
@@ -328,7 +328,7 @@ class DaikinBRP084(Appliance):
         if value < -3.0 or value > 0.0 or abs(doubled - round(doubled)) > 1e-9:
             raise ValueError("Dry comfort offset must be -3.0..0.0 in 0.5 steps")
         return (
-            int(round(doubled)).to_bytes(1, byteorder='big', signed=True).hex().upper()
+            int(round(doubled)).to_bytes(1, byteorder="big", signed=True).hex().upper()
         )
 
     @staticmethod
@@ -560,14 +560,14 @@ class DaikinBRP084(Appliance):
 
         # Dry-mode comfort offset (STD +/- bias), not a normal target temp.
         try:
-            self.values['dry_comfort_offset'] = str(
+            self.values["dry_comfort_offset"] = str(
                 self.hex_to_dry_comfort_offset(
                     self.find_value_by_pn(
                         response, *self.get_path("dry_comfort_offset")
                     )
                 )
             )
-        except (DaikinException, ValueError):
+        except (DaikinException, TypeError, ValueError):
             pass
 
         # Adapter capability flags. The firmware version ('ver') is already
@@ -702,16 +702,16 @@ class DaikinBRP084(Appliance):
 
     def _handle_dry_comfort_offset_setting(self, settings, requests):
         """Handle dry-mode comfort offset settings."""
-        if 'dry_comfort_offset' not in settings or self.values.get('mode') != 'dry':
+        if "dry_comfort_offset" not in settings or self.values.get("mode") != "dry":
             return
 
         path = self.get_path("dry_comfort_offset")
         try:
-            offset_hex = self.dry_comfort_offset_to_hex(settings['dry_comfort_offset'])
+            offset_hex = self.dry_comfort_offset_to_hex(settings["dry_comfort_offset"])
         except (TypeError, ValueError):
             _LOGGER.warning(
                 "Invalid dry comfort offset %r; no write will be sent",
-                settings['dry_comfort_offset'],
+                settings["dry_comfort_offset"],
             )
             return
         self.add_request(requests, path, offset_hex)
@@ -909,16 +909,16 @@ class DaikinBRP084(Appliance):
     @property
     def dry_comfort_offset(self) -> Optional[float]:
         """Return dry-mode comfort offset in degrees Celsius."""
-        return self._parse_number('dry_comfort_offset')
+        return self._parse_number("dry_comfort_offset")
 
     @property
     def support_dry_comfort_offset(self) -> bool:
         """Return True if the device exposes dry-mode comfort offset."""
-        return 'dry_comfort_offset' in self.values
+        return "dry_comfort_offset" in self.values
 
     async def set_dry_comfort_offset(self, offset):
         """Set the dry-mode comfort offset in degrees Celsius."""
-        await self.set({'dry_comfort_offset': offset})
+        await self.set({"dry_comfort_offset": offset})
 
     async def set_econo_mode(self, mode):
         """Enable or disable Econo mode ('on'/'off')."""

--- a/tests/test_daikin_brp084.py
+++ b/tests/test_daikin_brp084.py
@@ -50,6 +50,10 @@ async def test_daikin_brp084(aresponses, client_session):
                                             "pn": "p_06",
                                             "pv": "000000",
                                         },  # Horizontal swing OFF
+                                        {
+                                            "pn": "p_34",
+                                            "pv": "FD",
+                                        },  # Dry comfort offset (-1.5°C)
                                     ],
                                 },
                                 {
@@ -208,6 +212,9 @@ async def test_daikin_brp084(aresponses, client_session):
     assert device.values.get('mac') == '112233445566'
 
     # New reads: comfort airflow, capabilities, outdoor sensors, models
+    assert device.values.get('dry_comfort_offset') == '-1.5'
+    assert device.support_dry_comfort_offset is True
+    assert device.dry_comfort_offset == -1.5
     assert device.values.get('comfort') == 'off'
     assert device.support_comfort_mode is True
     assert device.comfort_mode == 'off'
@@ -585,6 +592,41 @@ def test_hex_le_to_temp(value, expected):
 @pytest.mark.parametrize(
     'value, expected',
     [
+        ('FA', -3.0),
+        ('FD', -1.5),
+        ('FE', -1.0),
+        ('00', 0.0),
+    ],
+)
+def test_hex_to_dry_comfort_offset(value, expected):
+    """Dry comfort offset is a signed one-byte half-degree value."""
+    assert DaikinBRP084.hex_to_dry_comfort_offset(value) == expected
+
+
+@pytest.mark.parametrize(
+    'offset, expected',
+    [
+        (-3.0, 'FA'),
+        (-1.5, 'FD'),
+        (-1.0, 'FE'),
+        (0.0, '00'),
+    ],
+)
+def test_dry_comfort_offset_to_hex(offset, expected):
+    """Dry comfort offset encoding matches observed BRP084 values."""
+    assert DaikinBRP084.dry_comfort_offset_to_hex(offset) == expected
+
+
+@pytest.mark.parametrize('offset', [-3.5, 0.5, -1.25, 'bogus'])
+def test_invalid_dry_comfort_offset(offset):
+    """Dry comfort offset is limited to -3.0..0.0 in half-degree steps."""
+    with pytest.raises(ValueError):
+        DaikinBRP084.dry_comfort_offset_to_hex(offset)
+
+
+@pytest.mark.parametrize(
+    'value, expected',
+    [
         ('2020202020414D564131374D585446', 'AMVA17MXTF'),
         ('202020202020202031313230303045', '112000E'),
         ('notvalidhex', 'notvalidhex'),  # falls back to input
@@ -690,6 +732,53 @@ def test_handle_vane_setting():
     requests = []
     device._handle_vane_setting({'vane_vertical': 'down'}, requests)
     assert len(requests) == 0
+
+
+def test_handle_dry_comfort_offset_setting():
+    """Dry comfort offset writes the BRP084 dry-mode bias field."""
+    mock_session = MagicMock()
+    device = DaikinBRP084('127.0.0.1', session=mock_session)
+    device.values.update({'mode': 'dry'})
+
+    requests = []
+    device._handle_dry_comfort_offset_setting({'dry_comfort_offset': -1.5}, requests)
+
+    assert len(requests) == 1
+    assert requests[0].name == 'p_34'
+    assert requests[0].value == 'FD'
+    assert requests[0].path == ['e_1002', 'e_3001']
+    assert requests[0].to == '/dsiot/edge/adr_0100.dgc_status'
+
+
+def test_dry_comfort_offset_no_write_outside_dry_mode():
+    """Dry comfort offset is only written while the device mode is dry."""
+    mock_session = MagicMock()
+    device = DaikinBRP084('127.0.0.1', session=mock_session)
+    device.values.update({'mode': 'cool'})
+
+    requests = []
+    device._handle_dry_comfort_offset_setting({'dry_comfort_offset': -1.5}, requests)
+
+    assert len(requests) == 0
+
+
+@pytest.mark.parametrize('offset', [-3.5, 0.5, -1.25, 'bogus'])
+def test_invalid_dry_comfort_offset_setting_no_write(offset, caplog):
+    """Invalid dry comfort offset settings do not send malformed requests."""
+    import logging
+
+    mock_session = MagicMock()
+    device = DaikinBRP084('127.0.0.1', session=mock_session)
+    device.values.update({'mode': 'dry'})
+    requests = []
+
+    with caplog.at_level(logging.WARNING):
+        device._handle_dry_comfort_offset_setting(
+            {'dry_comfort_offset': offset}, requests
+        )
+
+    assert len(requests) == 0
+    assert "Invalid dry comfort offset" in caplog.text
 
 
 def test_vane_overrides_swing_vertical():
@@ -990,6 +1079,7 @@ def test_unrecognized_mode_logs_warning(client_session, caplog):
         ('set_outdoor_quiet_mode', 'on', {'outdoor_quiet': 'on'}),
         ('set_powerful_mode', 'on', {'powerful': 'on'}),
         ('set_vertical_vane', 'down', {'vane_vertical': 'down'}),
+        ('set_dry_comfort_offset', -1.5, {'dry_comfort_offset': -1.5}),
     ],
 )
 async def test_feature_convenience_setters(method, arg, expected):
@@ -1014,6 +1104,11 @@ async def test_feature_convenience_setters(method, arg, expected):
             'on',
         ),
         ({'powerful': 'on'}, ('support_powerful_mode', 'powerful_mode'), 'on'),
+        (
+            {'dry_comfort_offset': '-1.5'},
+            ('support_dry_comfort_offset', 'dry_comfort_offset'),
+            -1.5,
+        ),
     ],
 )
 def test_feature_support_and_current(values, support, current):
@@ -1051,7 +1146,14 @@ def test_extract_optional_readings_guards_missing_containers():
     # DaikinException and is swallowed.
     device._extract_optional_readings({'responses': []})
 
-    for key in ('comfort', 'econo', 'outdoor_quiet', 'powerful', 'vane_vertical'):
+    for key in (
+        'comfort',
+        'econo',
+        'outdoor_quiet',
+        'powerful',
+        'vane_vertical',
+        'dry_comfort_offset',
+    ):
         assert key not in device.values
 
 
@@ -1161,7 +1263,10 @@ async def test_update_status_dry_mode():
                                     },
                                     {
                                         "pn": "e_3001",
-                                        "pch": [{"pn": "p_01", "pv": "0500"}],
+                                        "pch": [
+                                            {"pn": "p_01", "pv": "0500"},
+                                            {"pn": "p_34", "pv": "FE"},
+                                        ],
                                     },
                                     {
                                         "pn": "e_A00B",
@@ -1191,6 +1296,9 @@ async def test_update_status_dry_mode():
     assert device.values['otemp'] == '--'
     assert device.values['hhum'] == '--'
     assert device.values['f_dir'] == 'off'
+    assert device.target_temperature is None
+    assert device.dry_comfort_offset == -1.0
+    assert device.support_dry_comfort_offset is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_daikin_brp084.py
+++ b/tests/test_daikin_brp084.py
@@ -50,10 +50,6 @@ async def test_daikin_brp084(aresponses, client_session):
                                             "pn": "p_06",
                                             "pv": "000000",
                                         },  # Horizontal swing OFF
-                                        {
-                                            "pn": "p_34",
-                                            "pv": "FD",
-                                        },  # Dry comfort offset (-1.5°C)
                                     ],
                                 },
                                 {
@@ -212,9 +208,6 @@ async def test_daikin_brp084(aresponses, client_session):
     assert device.values.get('mac') == '112233445566'
 
     # New reads: comfort airflow, capabilities, outdoor sensors, models
-    assert device.values.get('dry_comfort_offset') == '-1.5'
-    assert device.support_dry_comfort_offset is True
-    assert device.dry_comfort_offset == -1.5
     assert device.values.get('comfort') == 'off'
     assert device.support_comfort_mode is True
     assert device.comfort_mode == 'off'
@@ -590,12 +583,12 @@ def test_hex_le_to_temp(value, expected):
 
 
 @pytest.mark.parametrize(
-    'value, expected',
+    "value, expected",
     [
-        ('FA', -3.0),
-        ('FD', -1.5),
-        ('FE', -1.0),
-        ('00', 0.0),
+        ("FA", -3.0),
+        ("FD", -1.5),
+        ("FE", -1.0),
+        ("00", 0.0),
     ],
 )
 def test_hex_to_dry_comfort_offset(value, expected):
@@ -604,12 +597,12 @@ def test_hex_to_dry_comfort_offset(value, expected):
 
 
 @pytest.mark.parametrize(
-    'offset, expected',
+    "offset, expected",
     [
-        (-3.0, 'FA'),
-        (-1.5, 'FD'),
-        (-1.0, 'FE'),
-        (0.0, '00'),
+        (-3.0, "FA"),
+        (-1.5, "FD"),
+        (-1.0, "FE"),
+        (0.0, "00"),
     ],
 )
 def test_dry_comfort_offset_to_hex(offset, expected):
@@ -617,7 +610,7 @@ def test_dry_comfort_offset_to_hex(offset, expected):
     assert DaikinBRP084.dry_comfort_offset_to_hex(offset) == expected
 
 
-@pytest.mark.parametrize('offset', [-3.5, 0.5, -1.25, 'bogus'])
+@pytest.mark.parametrize("offset", [-3.5, 0.5, -1.25, "bogus"])
 def test_invalid_dry_comfort_offset(offset):
     """Dry comfort offset is limited to -3.0..0.0 in half-degree steps."""
     with pytest.raises(ValueError):
@@ -737,44 +730,44 @@ def test_handle_vane_setting():
 def test_handle_dry_comfort_offset_setting():
     """Dry comfort offset writes the BRP084 dry-mode bias field."""
     mock_session = MagicMock()
-    device = DaikinBRP084('127.0.0.1', session=mock_session)
-    device.values.update({'mode': 'dry'})
+    device = DaikinBRP084("127.0.0.1", session=mock_session)
+    device.values.update({"mode": "dry"})
 
     requests = []
-    device._handle_dry_comfort_offset_setting({'dry_comfort_offset': -1.5}, requests)
+    device._handle_dry_comfort_offset_setting({"dry_comfort_offset": -1.5}, requests)
 
     assert len(requests) == 1
-    assert requests[0].name == 'p_34'
-    assert requests[0].value == 'FD'
-    assert requests[0].path == ['e_1002', 'e_3001']
-    assert requests[0].to == '/dsiot/edge/adr_0100.dgc_status'
+    assert requests[0].name == "p_34"
+    assert requests[0].value == "FD"
+    assert requests[0].path == ["e_1002", "e_3001"]
+    assert requests[0].to == "/dsiot/edge/adr_0100.dgc_status"
 
 
 def test_dry_comfort_offset_no_write_outside_dry_mode():
     """Dry comfort offset is only written while the device mode is dry."""
     mock_session = MagicMock()
-    device = DaikinBRP084('127.0.0.1', session=mock_session)
-    device.values.update({'mode': 'cool'})
+    device = DaikinBRP084("127.0.0.1", session=mock_session)
+    device.values.update({"mode": "cool"})
 
     requests = []
-    device._handle_dry_comfort_offset_setting({'dry_comfort_offset': -1.5}, requests)
+    device._handle_dry_comfort_offset_setting({"dry_comfort_offset": -1.5}, requests)
 
     assert len(requests) == 0
 
 
-@pytest.mark.parametrize('offset', [-3.5, 0.5, -1.25, 'bogus'])
+@pytest.mark.parametrize("offset", [-3.5, 0.5, -1.25, "bogus"])
 def test_invalid_dry_comfort_offset_setting_no_write(offset, caplog):
     """Invalid dry comfort offset settings do not send malformed requests."""
     import logging
 
     mock_session = MagicMock()
-    device = DaikinBRP084('127.0.0.1', session=mock_session)
-    device.values.update({'mode': 'dry'})
+    device = DaikinBRP084("127.0.0.1", session=mock_session)
+    device.values.update({"mode": "dry"})
     requests = []
 
     with caplog.at_level(logging.WARNING):
         device._handle_dry_comfort_offset_setting(
-            {'dry_comfort_offset': offset}, requests
+            {"dry_comfort_offset": offset}, requests
         )
 
     assert len(requests) == 0
@@ -1079,7 +1072,6 @@ def test_unrecognized_mode_logs_warning(client_session, caplog):
         ('set_outdoor_quiet_mode', 'on', {'outdoor_quiet': 'on'}),
         ('set_powerful_mode', 'on', {'powerful': 'on'}),
         ('set_vertical_vane', 'down', {'vane_vertical': 'down'}),
-        ('set_dry_comfort_offset', -1.5, {'dry_comfort_offset': -1.5}),
     ],
 )
 async def test_feature_convenience_setters(method, arg, expected):
@@ -1093,6 +1085,18 @@ async def test_feature_convenience_setters(method, arg, expected):
     device.set.assert_awaited_once_with(expected)
 
 
+@pytest.mark.asyncio
+async def test_set_dry_comfort_offset_delegates_to_set():
+    """Dry comfort offset convenience setter delegates to set()."""
+    mock_session = MagicMock()
+    device = DaikinBRP084("127.0.0.1", session=mock_session)
+    device.set = AsyncMock()
+
+    await device.set_dry_comfort_offset(-1.5)
+
+    device.set.assert_awaited_once_with({"dry_comfort_offset": -1.5})
+
+
 @pytest.mark.parametrize(
     'values, support, current',
     [
@@ -1104,11 +1108,6 @@ async def test_feature_convenience_setters(method, arg, expected):
             'on',
         ),
         ({'powerful': 'on'}, ('support_powerful_mode', 'powerful_mode'), 'on'),
-        (
-            {'dry_comfort_offset': '-1.5'},
-            ('support_dry_comfort_offset', 'dry_comfort_offset'),
-            -1.5,
-        ),
     ],
 )
 def test_feature_support_and_current(values, support, current):
@@ -1123,6 +1122,20 @@ def test_feature_support_and_current(values, support, current):
     device.values.update(values)
     assert getattr(device, support_prop) is True
     assert getattr(device, current_prop) == current
+
+
+def test_dry_comfort_offset_support_and_current():
+    """Dry comfort offset support is reported only once the value is present."""
+    mock_session = MagicMock()
+    device = DaikinBRP084("127.0.0.1", session=mock_session)
+
+    assert device.support_dry_comfort_offset is False
+    assert device.dry_comfort_offset is None
+
+    device.values.update({"dry_comfort_offset": "-1.5"})
+
+    assert device.support_dry_comfort_offset is True
+    assert device.dry_comfort_offset == -1.5
 
 
 def test_vertical_vane_property():
@@ -1146,15 +1159,54 @@ def test_extract_optional_readings_guards_missing_containers():
     # DaikinException and is swallowed.
     device._extract_optional_readings({'responses': []})
 
-    for key in (
-        'comfort',
-        'econo',
-        'outdoor_quiet',
-        'powerful',
-        'vane_vertical',
-        'dry_comfort_offset',
-    ):
+    for key in ('comfort', 'econo', 'outdoor_quiet', 'powerful', 'vane_vertical'):
         assert key not in device.values
+
+
+def test_dry_comfort_offset_missing_optional_reading_stays_unsupported():
+    """Missing dry comfort offset leaves support false and current value None."""
+    mock_session = MagicMock()
+    device = DaikinBRP084("127.0.0.1", session=mock_session)
+    device.values["mode"] = "cool"
+
+    device._extract_optional_readings({"responses": []})
+
+    assert "dry_comfort_offset" not in device.values
+    assert device.support_dry_comfort_offset is False
+    assert device.dry_comfort_offset is None
+
+
+def test_malformed_dry_comfort_offset_optional_reading_is_skipped():
+    """Malformed dry comfort offset values do not fail optional extraction."""
+    mock_session = MagicMock()
+    device = DaikinBRP084("127.0.0.1", session=mock_session)
+    device.values["mode"] = "dry"
+
+    device._extract_optional_readings(
+        {
+            "responses": [
+                {
+                    "fr": "/dsiot/edge/adr_0100.dgc_status",
+                    "pc": {
+                        "pn": "dgc_status",
+                        "pch": [
+                            {
+                                "pn": "e_1002",
+                                "pch": [
+                                    {
+                                        "pn": "e_3001",
+                                        "pch": [{"pn": "p_34", "pv": None}],
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+    )
+
+    assert "dry_comfort_offset" not in device.values
 
 
 @pytest.mark.parametrize(
@@ -1263,10 +1315,7 @@ async def test_update_status_dry_mode():
                                     },
                                     {
                                         "pn": "e_3001",
-                                        "pch": [
-                                            {"pn": "p_01", "pv": "0500"},
-                                            {"pn": "p_34", "pv": "FE"},
-                                        ],
+                                        "pch": [{"pn": "p_01", "pv": "0500"}],
                                     },
                                     {
                                         "pn": "e_A00B",
@@ -1296,9 +1345,61 @@ async def test_update_status_dry_mode():
     assert device.values['otemp'] == '--'
     assert device.values['hhum'] == '--'
     assert device.values['f_dir'] == 'off'
-    assert device.target_temperature is None
-    assert device.dry_comfort_offset == -1.0
+
+
+@pytest.mark.asyncio
+async def test_update_status_dry_comfort_offset():
+    """Dry comfort offset is exposed separately from target temperature."""
+    device = DaikinBRP084("ip", session=MagicMock())
+    device._get_resource = AsyncMock(
+        return_value={
+            "responses": [
+                {
+                    "fr": "/dsiot/edge/adr_0100.dgc_status",
+                    "pc": {
+                        "pn": "dgc_status",
+                        "pch": [
+                            {
+                                "pn": "e_1002",
+                                "pch": [
+                                    {
+                                        "pn": "e_A002",
+                                        "pch": [{"pn": "p_01", "pv": "01"}],
+                                    },
+                                    {
+                                        "pn": "e_3001",
+                                        "pch": [
+                                            {"pn": "p_01", "pv": "0500"},
+                                            {"pn": "p_34", "pv": "FE"},
+                                        ],
+                                    },
+                                    {
+                                        "pn": "e_A00B",
+                                        "pch": [{"pn": "p_01", "pv": "18"}],
+                                    },
+                                ],
+                            }
+                        ],
+                    },
+                },
+                {
+                    "fr": "/dsiot/edge.adp_i",
+                    "pc": {
+                        "pn": "adp_i",
+                        "pch": [{"pn": "mac", "pv": "112233445566"}],
+                    },
+                },
+            ]
+        }
+    )
+
+    await device.update_status()
+
+    assert device.values["mode"] == "dry"
+    assert device.values["dry_comfort_offset"] == "-1.0"
     assert device.support_dry_comfort_offset is True
+    assert device.dry_comfort_offset == -1.0
+    assert device.target_temperature is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Some BRP084/dsiot units expose a dry-mode comfort offset used by the remote as a relative `STD` bias, for example `STD -1.5 C`. This is not an absolute temperature setpoint and should not be mapped to the normal `stemp`/`target_temperature` path.

On observed BRP084/dsiot firmware `3_12_3` / API `2_2` responses, the field is present at `e_1002/e_3001/p_34` with metadata range `FA..00`. The value is a signed one-byte half-degree offset:

- `FA` -> `-3.0`
- `FD` -> `-1.5`
- `FE` -> `-1.0`
- `00` -> `0.0`

Other `p_34` properties can appear under different containers, so this PR intentionally targets only the exact `e_1002/e_3001/p_34` path. Broader model coverage is unknown.

## Change

- Add conditional BRP084 support for `dry_comfort_offset`.
- Decode and encode signed one-byte half-degree values.
- Expose `dry_comfort_offset`, `support_dry_comfort_offset`, and `set_dry_comfort_offset(offset)`.
- Only report support when the field is actually present in the status response.
- Keep dry comfort offset separate from `stemp` / normal target temperature.
- Validate writes to `-3.0..0.0` in `0.5` degree steps, and skip malformed writes rather than sending invalid payloads.

## Tests

- `uv run pytest tests/test_daikin_brp084.py -q`
- `uv run pytest -q`
- `uvx pre-commit run --files pydaikin/daikin_brp084.py tests/test_daikin_brp084.py`
- `uvx ruff format --check pydaikin/daikin_brp084.py tests/test_daikin_brp084.py && uvx ruff check .`