### PR TITLE
fix: tolerate pc nodes without 'pn' in BRP084 find_value_by_pn

### DIFF
--- a/pydaikin/daikin_brp084.py
+++ b/pydaikin/daikin_brp084.py
@@ -343,22 +343,27 @@ class DaikinBRP084(Appliance):
 
     @staticmethod
     def find_value_by_pn(data: dict, fr: str, *keys):
-        """Find values in nested response data."""
-        data = [x['pc'] for x in data['responses'] if x['fr'] == fr]
+        """Find values in nested response data.
+
+        Tolerates malformed entries: some firmwares (e.g. 3.15.0-g4) return
+        ``pc`` nodes without a ``pn`` (or without a ``pch`` container), which
+        must be skipped instead of raising ``KeyError``.
+        """
+        data = [x["pc"] for x in data["responses"] if x.get("fr") == fr and "pc" in x]
 
         while keys:
             current_key = keys[0]
             keys = keys[1:]
             found = False
             for pcs in data:
-                if pcs['pn'] == current_key:
+                if pcs.get("pn") == current_key:
                     if not keys:
-                        return pcs['pv']
-                    data = pcs['pch']
+                        return pcs["pv"]
+                    data = pcs.get("pch") or []
                     found = True
                     break
             if not found:
-                raise DaikinException(f'Key {current_key} not found')
+                raise DaikinException(f"Key {current_key} not found")
         return None
 
     def get_swing_state(self, data: dict) -> str:

--- a/tests/test_daikin_brp084.py
+++ b/tests/test_daikin_brp084.py
@@ -1230,6 +1230,123 @@ def test_find_value_by_pn_no_keys():
     assert DaikinBRP084.find_value_by_pn({'responses': []}, 'fr') is None
 
 
+def test_find_value_by_pn_skips_entries_without_pn():
+    """Entries lacking a 'pn' key are skipped instead of raising KeyError.
+
+    Regression test for https://github.com/home-assistant/core/issues/179963:
+    firmware 3.15.0-g4 returns pc nodes without 'pn', which used to abort
+    setup with KeyError: 'pn'.
+    """
+    response = {
+        "responses": [
+            {
+                "fr": "/dsiot/edge/adr_0100.i_power.week_power",
+                "pc": {
+                    "pn": "week_power",
+                    "pch": [
+                        {"pv": "999"},  # malformed: no 'pn'
+                        {"pn": "today_runtime", "pv": "120"},
+                    ],
+                },
+            }
+        ]
+    }
+
+    value = DaikinBRP084.find_value_by_pn(
+        response,
+        "/dsiot/edge/adr_0100.i_power.week_power",
+        "week_power",
+        "today_runtime",
+    )
+    assert value == "120"
+
+
+def test_find_value_by_pn_missing_key_raises_daikin_exception():
+    """A genuinely missing key raises DaikinException, not KeyError."""
+    response = {
+        "responses": [
+            {
+                "fr": "/dsiot/edge/adr_0100.i_power.week_power",
+                "pc": {"pn": "week_power", "pch": [{"pv": "999"}]},
+            }
+        ]
+    }
+
+    with pytest.raises(DaikinException, match="Key today_runtime not found"):
+        DaikinBRP084.find_value_by_pn(
+            response,
+            "/dsiot/edge/adr_0100.i_power.week_power",
+            "week_power",
+            "today_runtime",
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_status_tolerates_energy_response_without_pn():
+    """A week_power payload with pn-less nodes does not abort update_status.
+
+    Mirrors the failure in https://github.com/home-assistant/core/issues/179963:
+    energy/runtime data must be optional so device setup can complete.
+    """
+    device = DaikinBRP084('ip', session=MagicMock())
+    device._get_resource = AsyncMock(
+        return_value={
+            "responses": [
+                {
+                    "fr": "/dsiot/edge/adr_0100.dgc_status",
+                    "pc": {
+                        "pn": "dgc_status",
+                        "pch": [
+                            {
+                                "pn": "e_1002",
+                                "pch": [
+                                    {
+                                        "pn": "e_A002",
+                                        "pch": [{"pn": "p_01", "pv": "01"}],
+                                    },
+                                    {
+                                        "pn": "e_3001",
+                                        "pch": [
+                                            {"pn": "p_01", "pv": "0200"},
+                                            {"pn": "p_02", "pv": "32"},
+                                            {"pn": "p_09", "pv": "0A00"},
+                                            {"pn": "p_05", "pv": "000000"},
+                                            {"pn": "p_06", "pv": "000000"},
+                                        ],
+                                    },
+                                    {
+                                        "pn": "e_A00B",
+                                        "pch": [{"pn": "p_01", "pv": "18"}],
+                                    },
+                                ],
+                            }
+                        ],
+                    },
+                },
+                {
+                    "fr": "/dsiot/edge/adr_0100.i_power.week_power",
+                    # Malformed: children lack 'pn' (firmware 3.15.0-g4).
+                    "pc": {"pn": "week_power", "pch": [{"pv": "999"}]},
+                },
+                {
+                    "fr": "/dsiot/edge.adp_i",
+                    "pc": {
+                        "pn": "adp_i",
+                        "pch": [{"pn": "mac", "pv": "112233445566"}],
+                    },
+                },
+            ]
+        }
+    )
+
+    await device.update_status()
+
+    assert device.values['mode'] == 'cool'
+    assert device.values['mac'] == '112233445566'
+    assert 'today_runtime' not in device.values
+    assert 'datas' not in device.values
+
+
 def _swing_state_response(vertical, horizontal):
     """Build a minimal adr_0100 response exposing cool-mode swing values."""
     return {


### PR DESCRIPTION
## Summary
Firmware 3.15.0-g4 returns DSIOT `pc` nodes that lack a `pn` key, so `find_value_by_pn()` raised a raw `KeyError: 'pn'` instead of the expected `DaikinException`, aborting device setup in Home Assistant while processing `today_runtime`.

- Skip `pc` nodes without `pn` (and missing `pch`/missing response `pc`) instead of raising `KeyError`; a genuinely missing key still raises `DaikinException`, which callers already guard.
- Add regression tests: direct unit tests for `find_value_by_pn` plus an integration-style test asserting `update_status()` completes when the energy payload is malformed.

## Related issue
Fixes https://github.com/home-assistant/core/issues/179963, https://github.com/fredrike/pydaikin/issues/156

## Checklist
- [x] Tests added and passing locally (`343 passed, 5 skipped`)
- [x] pre-commit hooks pass (ruff, ruff format, pylint)