### PR TITLE
Clear unsupported-device error for DGC adapters on pre-2.8.0 firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ If you have a device with firmware 2.8.0 that is not working correctly, please o
 The following device and firmware combinations are not currently supported:
 
 * BRP069C4x with firmware version 2.0.0
+* Adapters with Onecta firmware below 2.8.0 (e.g. the built-in WiFi adapter of
+  newer Stylish units such as FTXA20C2V1BW, and BRP069C4x/C8x gateways running
+  2.3.x-2.6.x). These answer UDP discovery with `type=GPF,protocol=DGC` but
+  return 404 for every local HTTP endpoint - there is no local control API.
+  Local control requires adapter firmware 2.8.0 or later; until then use a
+  cloud-based integration ([#153](https://github.com/fredrike/pydaikin/issues/153),
+  [#83](https://github.com/fredrike/pydaikin/issues/83))
 
 ## About
 

--- a/pydaikin/daikin_brp084.py
+++ b/pydaikin/daikin_brp084.py
@@ -343,22 +343,27 @@ class DaikinBRP084(Appliance):
 
     @staticmethod
     def find_value_by_pn(data: dict, fr: str, *keys):
-        """Find values in nested response data."""
-        data = [x['pc'] for x in data['responses'] if x['fr'] == fr]
+        """Find values in nested response data.
+
+        Tolerates malformed entries: some firmwares (e.g. 3.15.0-g4) return
+        ``pc`` nodes without a ``pn`` (or without a ``pch`` container), which
+        must be skipped instead of raising ``KeyError``.
+        """
+        data = [x["pc"] for x in data["responses"] if x.get("fr") == fr and "pc" in x]
 
         while keys:
             current_key = keys[0]
             keys = keys[1:]
             found = False
             for pcs in data:
-                if pcs['pn'] == current_key:
+                if pcs.get("pn") == current_key:
                     if not keys:
-                        return pcs['pv']
-                    data = pcs['pch']
+                        return pcs["pv"]
+                    data = pcs.get("pch") or []
                     found = True
                     break
             if not found:
-                raise DaikinException(f'Key {current_key} not found')
+                raise DaikinException(f"Key {current_key} not found")
         return None
 
     def get_swing_state(self, data: dict) -> str:

--- a/pydaikin/discovery.py
+++ b/pydaikin/discovery.py
@@ -91,6 +91,19 @@ def get_devices():
     return discovery.poll()
 
 
+def get_device_by_ip(ip):
+    """Returns the info of a discovered device matching the given IP."""
+    discovery = Discovery()
+
+    devices = discovery.poll()
+
+    for device in devices:
+        if device.get("ip") == ip:
+            return device
+
+    return None
+
+
 def get_name(name):
     """Returns the name of discovered devices."""
     discovery = Discovery()

--- a/pydaikin/factory.py
+++ b/pydaikin/factory.py
@@ -14,7 +14,7 @@ from .daikin_brp069 import DaikinBRP069
 from .daikin_brp072c import DaikinBRP072C
 from .daikin_brp084 import DaikinBRP084
 from .daikin_skyfi import DaikinSkyFi
-from .discovery import get_name
+from .discovery import get_device_by_ip, get_name
 from .exceptions import DaikinException
 
 _LOGGER = logging.getLogger(__name__)
@@ -103,9 +103,26 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
             setattr(obj, "_own_session", True)
         try:
             if not already_initialized:
-                await obj.init()
+                try:
+                    await obj.init()
+                except DaikinException as err:
+                    # The last-resort driver could not read any values at all.
+                    # If discovery identifies a known unsupported fingerprint,
+                    # report it instead of the bare exception.
+                    if not isinstance(obj, DaikinAirBase):
+                        raise
+                    discovery_info = self._get_discovery_info(device_ip)
+                    if discovery_info is None:
+                        raise
+                    raise DaikinException(
+                        self._unsupported_device_message(obj, device_id, discovery_info)
+                    ) from err
             if not obj.values.get("mode"):
-                raise DaikinException(self._unsupported_device_message(obj, device_id))
+                raise DaikinException(
+                    self._unsupported_device_message(
+                        obj, device_id, self._get_discovery_info(device_ip)
+                    )
+                )
         except Exception:
             if own_session:
                 await obj.aclose()
@@ -142,12 +159,18 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
             return None
 
     @staticmethod
-    def _unsupported_device_message(obj: Appliance, device_id: str) -> str:
+    def _unsupported_device_message(
+        obj: Appliance,
+        device_id: str,
+        discovery_info: Optional[dict] = None,
+    ) -> str:
         """Build a clear error message for a detected but unsupported device.
 
         Some adapters answer /common/basic_info (so type, subtype and firmware
         are known) but expose no control API. A known example is the BRP069C8x
         running firmware 2.3.x, which returns 404 for every /aircon endpoint.
+        Other adapters answer UDP discovery only, with every HTTP endpoint
+        returning 404 - for those ``discovery_info`` carries the fingerprint.
         """
         values = obj.values
         device_type = values.get("type", invalidate=False)
@@ -165,6 +188,27 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
                 f"BRP069C8x with firmware {firmware.replace('_', '.')} is not "
                 "supported by pydaikin."
             )
+
+        # Adapters speaking the DGC protocol (Onecta generation) with firmware
+        # before 2.8.0 respond to UDP discovery but expose no local control
+        # API at all - every HTTP endpoint returns 404. Known examples are the
+        # built-in WiFi adapters of newer Stylish units (issue #153) and
+        # BRP069C4x/C8x gateways (issues #83, #116).
+        if discovery_info:
+            protocol = discovery_info.get("protocol")
+            disc_firmware = discovery_info.get("ver")
+            if protocol == "DGC" and DaikinFactory._is_pre_multireq_firmware(
+                disc_firmware
+            ):
+                disc_type = discovery_info.get("type", "unknown")
+                return (
+                    f"Error creating device, {device_id} is not supported: "
+                    f"detected {disc_type}/{protocol} adapter with firmware "
+                    f"{disc_firmware.replace('_', '.')}, but its local "
+                    "control API requires adapter firmware 2.8.0 or later. "
+                    "Update the adapter via the Onecta app, or control the "
+                    "device through the Daikin cloud."
+                )
 
         details = []
         if device_type:
@@ -184,6 +228,29 @@ class DaikinFactory:  # pylint: disable=too-few-public-methods
                 "by pydaikin."
             )
         return f"Error creating device, {device_id} is not supported."
+
+    @staticmethod
+    def _is_pre_multireq_firmware(ver: Optional[str]) -> bool:
+        """Return True for DGC adapter firmware lacking /dsiot/multireq.
+
+        Adapter firmware 2.8.0 introduced the local JSON API; earlier 2.x
+        releases (e.g. 2_6_1) provide no local control endpoints at all.
+        Malformed versions are treated as not matching this fingerprint.
+        """
+        try:
+            major, minor = (int(part) for part in ver.split("_")[:2])
+        except (AttributeError, ValueError):
+            return False
+        return (major, minor) < (2, 8)
+
+    @staticmethod
+    def _get_discovery_info(device_ip: str) -> Optional[dict]:
+        """Best-effort lookup of UDP discovery attributes for the device IP."""
+        try:
+            return get_device_by_ip(device_ip)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug("Error looking up device via discovery: %s", err)
+            return None
 
     @staticmethod
     def _extract_ip_port(device_id: str) -> Tuple[str, Optional[int]]:

--- a/tests/test_daikin_brp084.py
+++ b/tests/test_daikin_brp084.py
@@ -1230,6 +1230,123 @@ def test_find_value_by_pn_no_keys():
     assert DaikinBRP084.find_value_by_pn({'responses': []}, 'fr') is None
 
 
+def test_find_value_by_pn_skips_entries_without_pn():
+    """Entries lacking a 'pn' key are skipped instead of raising KeyError.
+
+    Regression test for https://github.com/home-assistant/core/issues/179963:
+    firmware 3.15.0-g4 returns pc nodes without 'pn', which used to abort
+    setup with KeyError: 'pn'.
+    """
+    response = {
+        "responses": [
+            {
+                "fr": "/dsiot/edge/adr_0100.i_power.week_power",
+                "pc": {
+                    "pn": "week_power",
+                    "pch": [
+                        {"pv": "999"},  # malformed: no 'pn'
+                        {"pn": "today_runtime", "pv": "120"},
+                    ],
+                },
+            }
+        ]
+    }
+
+    value = DaikinBRP084.find_value_by_pn(
+        response,
+        "/dsiot/edge/adr_0100.i_power.week_power",
+        "week_power",
+        "today_runtime",
+    )
+    assert value == "120"
+
+
+def test_find_value_by_pn_missing_key_raises_daikin_exception():
+    """A genuinely missing key raises DaikinException, not KeyError."""
+    response = {
+        "responses": [
+            {
+                "fr": "/dsiot/edge/adr_0100.i_power.week_power",
+                "pc": {"pn": "week_power", "pch": [{"pv": "999"}]},
+            }
+        ]
+    }
+
+    with pytest.raises(DaikinException, match="Key today_runtime not found"):
+        DaikinBRP084.find_value_by_pn(
+            response,
+            "/dsiot/edge/adr_0100.i_power.week_power",
+            "week_power",
+            "today_runtime",
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_status_tolerates_energy_response_without_pn():
+    """A week_power payload with pn-less nodes does not abort update_status.
+
+    Mirrors the failure in https://github.com/home-assistant/core/issues/179963:
+    energy/runtime data must be optional so device setup can complete.
+    """
+    device = DaikinBRP084('ip', session=MagicMock())
+    device._get_resource = AsyncMock(
+        return_value={
+            "responses": [
+                {
+                    "fr": "/dsiot/edge/adr_0100.dgc_status",
+                    "pc": {
+                        "pn": "dgc_status",
+                        "pch": [
+                            {
+                                "pn": "e_1002",
+                                "pch": [
+                                    {
+                                        "pn": "e_A002",
+                                        "pch": [{"pn": "p_01", "pv": "01"}],
+                                    },
+                                    {
+                                        "pn": "e_3001",
+                                        "pch": [
+                                            {"pn": "p_01", "pv": "0200"},
+                                            {"pn": "p_02", "pv": "32"},
+                                            {"pn": "p_09", "pv": "0A00"},
+                                            {"pn": "p_05", "pv": "000000"},
+                                            {"pn": "p_06", "pv": "000000"},
+                                        ],
+                                    },
+                                    {
+                                        "pn": "e_A00B",
+                                        "pch": [{"pn": "p_01", "pv": "18"}],
+                                    },
+                                ],
+                            }
+                        ],
+                    },
+                },
+                {
+                    "fr": "/dsiot/edge/adr_0100.i_power.week_power",
+                    # Malformed: children lack 'pn' (firmware 3.15.0-g4).
+                    "pc": {"pn": "week_power", "pch": [{"pv": "999"}]},
+                },
+                {
+                    "fr": "/dsiot/edge.adp_i",
+                    "pc": {
+                        "pn": "adp_i",
+                        "pch": [{"pn": "mac", "pv": "112233445566"}],
+                    },
+                },
+            ]
+        }
+    )
+
+    await device.update_status()
+
+    assert device.values['mode'] == 'cool'
+    assert device.values['mac'] == '112233445566'
+    assert 'today_runtime' not in device.values
+    assert 'datas' not in device.values
+
+
 def _swing_state_response(vertical, horizontal):
     """Build a minimal adr_0100 response exposing cool-mode swing values."""
     return {

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -378,6 +378,123 @@ def test_unsupported_device_message_without_identity():
     )
 
 
+@pytest.mark.parametrize(
+    ("ver", "expected"),
+    [
+        ("2_0_0", True),
+        ("2_6_1", True),
+        ("2_7_9", True),
+        ("2_8_0", False),
+        ("2_10_0", False),
+        ("3_15_0", False),
+        (None, False),
+        ("bogus", False),
+    ],
+)
+def test_is_pre_multireq_firmware(ver, expected):
+    """Only DGC firmware versions below 2_8_0 match the unsupported fingerprint."""
+    assert DaikinFactory._is_pre_multireq_firmware(ver) is expected
+
+
+@pytest.mark.asyncio
+async def test_factory_unsupported_gpf_dgc_pre280_reports_cloud_only(
+    aresponses, client_session, monkeypatch
+):
+    """GPF/DGC adapters on pre-2.8.0 firmware report a clear cloud-only error (#153)."""
+    monkeypatch.setattr(
+        "pydaikin.factory.get_device_by_ip",
+        lambda ip: {
+            "ip": ip,
+            "port": 30050,
+            "type": "GPF",
+            "cdev": "RA",
+            "protocol": "DGC",
+            "reg": "eu",
+            "ver": "2_6_1",
+            "adp_kind": "4",
+            "mac": "24CD8D99XXXX",
+            "ssid": "DaikinAP54321",
+            "adp_mode": "ap_run",
+            "method": "home_only",
+        },
+    )
+
+    # Nothing answers over HTTP: multireq, legacy CGI and skyfi all 404.
+    aresponses.add(
+        path_pattern="/dsiot/multireq",
+        method_pattern="POST",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+    aresponses.add(
+        path_pattern="/common/basic_info",
+        method_pattern="GET",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+    for endpoint in (
+        "/skyfi/common/get_datetime",
+        "/skyfi/common/basic_info",
+        "/skyfi/aircon/get_control_info",
+        "/skyfi/aircon/get_model_info",
+        "/skyfi/aircon/get_sensor_info",
+        "/skyfi/aircon/get_zone_setting",
+    ):
+        aresponses.add(
+            path_pattern=endpoint,
+            method_pattern="GET",
+            response=aresponses.Response(status=404, text="Page Not Found"),
+        )
+
+    with pytest.raises(
+        DaikinException,
+        match=(
+            "GPF/DGC adapter with firmware 2\\.6\\.1.*"
+            "requires adapter firmware 2\\.8\\.0"
+        ),
+    ):
+        await DaikinFactory("192.168.127.1", session=client_session)
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
+@pytest.mark.asyncio
+async def test_factory_unsupported_gpf_dgc_without_discovery_keeps_bare_error(
+    aresponses, client_session, monkeypatch
+):
+    """Without a discovery fingerprint the previous bare error is preserved."""
+    monkeypatch.setattr("pydaikin.factory.get_device_by_ip", lambda ip: None)
+
+    aresponses.add(
+        path_pattern="/dsiot/multireq",
+        method_pattern="POST",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+    aresponses.add(
+        path_pattern="/common/basic_info",
+        method_pattern="GET",
+        response=aresponses.Response(status=404, text="Not Found"),
+    )
+    for endpoint in (
+        "/skyfi/common/get_datetime",
+        "/skyfi/common/basic_info",
+        "/skyfi/aircon/get_control_info",
+        "/skyfi/aircon/get_model_info",
+        "/skyfi/aircon/get_sensor_info",
+        "/skyfi/aircon/get_zone_setting",
+    ):
+        aresponses.add(
+            path_pattern=endpoint,
+            method_pattern="GET",
+            response=aresponses.Response(status=404, text="Page Not Found"),
+        )
+
+    with pytest.raises(DaikinException, match="^Empty values\\.$"):
+        await DaikinFactory("192.168.127.1", session=client_session)
+
+    aresponses.assert_all_requests_matched()
+    aresponses.assert_no_unused_routes()
+
+
 @pytest.mark.asyncio
 async def test_factory_detects_airbase(aresponses, client_session):
     """Test that factory correctly detects AirBase device (fallback from BRP069)."""


### PR DESCRIPTION
## Summary

Devices of the Onecta generation whose adapter firmware is below 2.8.0 (e.g. the built-in WiFi adapter of a 2026 Stylish FTXA20C2V1BW running 2.6.1, see #153, and the BRP069C4x/C8x gateway family from #83/#116) respond to UDP discovery with:

```
type=GPF,cdev=RA,protocol=DGC,ver=2_6_1,...,adp_kind=4,adp_mode=ap_run
```

but return **404 for every local HTTP endpoint** (`/dsiot/multireq`, `/common/basic_info`, `/skyfi/*`). The factory falls through all drivers and raises a bare `DaikinException: Empty values.` with no hint about what was detected or what to do next.

This PR reports a clear, actionable error instead:

```
Error creating device, 192.168.127.1 is not supported: detected GPF/DGC adapter
with firmware 2.6.1, but its local control API requires adapter firmware 2.8.0
or later. Update the adapter via the Onecta app, or control the device through
the Daikin cloud.
```

### Changes

* `pydaikin/discovery.py`: add `get_device_by_ip()` to look up discovery attributes by IP.
* `pydaikin/factory.py`:
  * `_unsupported_device_message()` accepts optional discovery info and detects the `protocol=DGC` + firmware `< 2_8_0` fingerprint (`_is_pre_multireq_firmware`).
  * When the last-resort AirBase driver raises `DaikinException("Empty values.")` and discovery identifies that fingerprint, it is replaced by the detailed message; without a fingerprint the previous behavior is unchanged.
  * Best-effort `_get_discovery_info()` only runs on the failure path, so successful connections pay no extra latency.
* `README.md`: document the unsupported pre-2.8.0 Onecta adapter family.
* `tests/test_factory.py`: fingerprint match case (from #153 logs), no-fingerprint regression case, and unit tests for the version check.

### Notes

* Same model family (FTXA25/50C2V1BW) works locally once on firmware 2.8.0+, so the message directs users to update rather than assuming the device can never be supported.
* Discovery lookup is wrapped in a broad try/except; if UDP broadcast is unavailable (common for HA containers), the generic error is preserved.

Fixes #153 (diagnostics part; actual local support requires Daikin to ship fw >= 2.8.0 / a discoverable local API)
