### PR TITLE
fix: rename demand control 'mode' to 'dmd_mode' to avoid collision with HVAC mode

### DIFF
--- a/pydaikin/daikin_base.py
+++ b/pydaikin/daikin_base.py
@@ -53,6 +53,11 @@ class Appliance(DaikinPowerMixin):
     # List of HTTP resource paths to fetch during status updates (overridden by subclasses)
     INFO_RESOURCES: list[str] = []
 
+    # Maps resource paths to key renames applied before storing in the flat
+    # values dict.  Use when different endpoints return the same key name with
+    # different semantics (e.g. "mode" in get_control_info vs get_demand_control).
+    RESOURCE_KEY_MAP: dict[str, dict[str, str]] = {}
+
     # Maximum number of concurrent HTTP requests to device
     MAX_CONCURRENT_REQUESTS = 4
 
@@ -291,7 +296,10 @@ class Appliance(DaikinPowerMixin):
                 _LOGGER.error("Exception in TaskGroup: %s", exc)
 
         for resource, task in zip(resources, tasks):
-            self.values.update_by_resource(resource, task.result())
+            data = task.result()
+            self.values.update_by_resource(
+                resource, data, key_map=self.RESOURCE_KEY_MAP.get(resource)
+            )
 
         self._register_energy_consumption_history()
 

--- a/pydaikin/daikin_brp069.py
+++ b/pydaikin/daikin_brp069.py
@@ -104,6 +104,8 @@ class DaikinBRP069(Appliance):
         'aircon/get_control_info',
     ]
 
+    RESOURCE_KEY_MAP = {"aircon/get_demand_control": {"mode": "dmd_mode"}}
+
     VALUES_SUMMARY = [
         'name',
         'ip',
@@ -385,6 +387,8 @@ class DaikinBRP069(Appliance):
         Returns the raw response of the endpoint, which includes:
         - ``en_demand``: "0" or "1", whether demand control is enabled.
         - ``mode``: "0" (manual), "1" (scheduled) or "2" (auto).
+          Note: stored as ``dmd_mode`` in the flat values dict to avoid
+          collision with the HVAC operating mode from get_control_info.
         - ``max_pow``: maximum power as a percentage (0-100).
         - schedule data: ``scdl_per_day`` and per-day counts (``moc``,
           ``tuc``, ...), plus per-event entries (``mo1_en``, ...) when a
@@ -421,4 +425,6 @@ class DaikinBRP069(Appliance):
         # The set response only returns ret=OK, so fetch the new state
         path = "aircon/get_demand_control"
         response = await self._get_resource(path)
-        self.values.update_by_resource(path, response)
+        self.values.update_by_resource(
+            path, response, key_map=self.RESOURCE_KEY_MAP.get(path)
+        )

--- a/pydaikin/values.py
+++ b/pydaikin/values.py
@@ -73,12 +73,28 @@ class ApplianceValues(MutableMapping):
         """Mark a resource as needing update, bypassing TTL cache."""
         self._last_update_by_resource.pop(resource, None)
 
-    def update_by_resource(self, resource: str, data: dict):
-        """Update the values and keep track of which resource provided them."""
-        self._data.update(data)
+    def update_by_resource(
+        self, resource: str, data: dict, key_map: dict[str, str] | None = None
+    ):
+        """Update the values and keep track of which resource provided them.
+
+        Args:
+            resource: The resource path that provided the data.
+            data: The response dict from the resource.
+            key_map: Optional mapping of original key names to renamed keys
+                stored in the flat values dict.  The raw response always
+                preserves the original keys.
+        """
         self._last_update_by_resource[resource] = datetime.now(timezone.utc)
         self._raw_by_resource[resource] = dict(data)
-        for k in data.keys():
+
+        if key_map:
+            remapped = {key_map.get(k, k): v for k, v in data.items()}
+        else:
+            remapped = data
+
+        self._data.update(remapped)
+        for k in remapped:
             self._resource_by_key[k] = resource
 
     def values_for_resource(self, resource: str, *, invalidate: bool = True):

--- a/tests/test_brp069_setters.py
+++ b/tests/test_brp069_setters.py
@@ -211,6 +211,8 @@ async def test_set_demand_control(aresponses, client_session):
 
     # State should be refreshed from the follow-up get request
     assert device.values.get("max_pow", invalidate=False) == "40"
+    # Demand control "mode" is remapped to "dmd_mode" in flat values
+    assert device.values.get("dmd_mode", invalidate=False) == "0"
 
     aresponses.assert_all_requests_matched()
 
@@ -251,3 +253,37 @@ async def test_get_info_resources_demand_control(aresponses, client_session):
 
     device.values["dmnd"] = "0"
     assert "aircon/get_demand_control" not in device.get_info_resources()
+
+
+@pytest.mark.asyncio
+async def test_update_status_demand_control_remapping(aresponses, client_session):
+    """Test that update_status remaps demand control 'mode' to 'dmd_mode'."""
+    aresponses.add(
+        path_pattern="/aircon/get_sensor_info",
+        method_pattern="GET",
+        response="ret=OK,htemp=25,otemp=20",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_control_info",
+        method_pattern="GET",
+        response="ret=OK,pow=1,mode=3,stemp=22",
+    )
+    aresponses.add(
+        path_pattern="/aircon/get_demand_control",
+        method_pattern="GET",
+        response="ret=OK,en_demand=1,mode=0,max_pow=45",
+    )
+
+    device = DaikinBRP069("192.168.1.100", session=client_session)
+    device.values["dmnd"] = "1"
+    await device.update_status()
+
+    # HVAC mode from get_control_info is stored as "mode"
+    assert device.values.get("mode", invalidate=False) == "3"
+    # Demand control mode is remapped to "dmd_mode"
+    assert device.values.get("dmd_mode", invalidate=False) == "0"
+    # Raw resource response still contains the original "mode" key
+    raw = device.values.values_for_resource(
+        "aircon/get_demand_control", invalidate=False
+    )
+    assert raw["mode"] == "0"


### PR DESCRIPTION
## Problem

`aircon/get_demand_control` and `aircon/get_control_info` both return a `mode` key with different semantics:

| Resource | `mode` meaning | Values |
|---|---|---|
| `get_control_info` | HVAC operating mode | 0=auto, 2=dry, 3=cool, 4=hot, 6=fan |
| `get_demand_control` | Demand control scheduling | 0=manual, 1=scheduled, 2=auto |

When `update_status()` fetches both, they merge into the same flat `values[mode]` via `update_by_resource()`. The last writer wins, corrupting the HVAC mode used by `set()`, `_update_settings()`, and `represent()`.

This was introduced in #149 when demand control support was added.

Fixes: #158 

## Solution

Add a `RESOURCE_KEY_MAP` mechanism so subclasses can declare key renames for specific resources:

- **`Appliance`** (`daikin_base.py`): New class attribute `RESOURCE_KEY_MAP` and a `key_map` parameter on `ApplianceValues.update_by_resource()`. When `update_status()` stores resource data, it applies the key map so conflicting keys are renamed in the flat values dict while the raw response preserves original keys.

- **`DaikinBRP069`** (`daikin_brp069.py`): Declares `RESOURCE_KEY_MAP = {"aircon/get_demand_control": {"mode": "dmd_mode"}}`. The demand control mode is now stored as `dmd_mode` in the flat values dict.

- **`ApplianceValues`** (`values.py`): `update_by_resource()` accepts an optional `key_map` parameter. Raw response (`_raw_by_resource`) always preserves original keys; only the flat `_data` and `_resource_by_key` use remapped keys.

## Impact

- `values["mode"]` now always contains the HVAC operating mode (from `get_control_info`)
- Demand control mode is accessible via `values["dmd_mode"]`
- `values_for_resource("aircon/get_demand_control")` still returns the original response with `mode`
- `get_demand_control()` returns raw response (unchanged API)

## Testing

- All 222 existing tests pass
- New test `test_update_status_demand_control_remapping` verifies the full flow
- Pre-commit (ruff, format, pylint) passes